### PR TITLE
Corrected Timeout Documentation

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Action/OriginateAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/OriginateAction.cs
@@ -141,7 +141,7 @@ namespace AsterNET.Manager.Action
         #region Timeout 
 
         /// <summary>
-        ///     Get/Set the timeout for the origination in seconds.<br />
+        ///     Get/Set the timeout for the origination in milliseconds.<br />
         ///     The channel must be answered within this time, otherwise the origination
         ///     is considered to have failed and an OriginateFailureEvent is generated.<br />
         ///     If not set, Asterisk assumes a default value of 30000 meaning 30 seconds.


### PR DESCRIPTION
Corrected the documentation of the Timeout property.

See: https://github.com/AsterNET/AsterNET/issues/61

I am not sure how I could change the default timeout value. It may be a part of the `SendAction` method that sends a `0` when it shouldn't.