### PR TITLE
QueuePenaltyAction Without Queue Argument

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Action/QueuePenaltyAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/QueuePenaltyAction.cs
@@ -12,9 +12,20 @@
         /// <summary>
         ///     Set the penalty for a queue member.
         /// </summary>
-        /// <param name="interface"></param>
-        /// <param name="penalty"></param>
-        /// <param name="queue"></param>
+        /// <param name="interface">The interface (tech/name) of the member whose penalty to change.</param>
+        /// <param name="penalty">The new penalty (number) for the member. Must be nonnegative.</param>
+        public QueuePenaltyAction(string @interface, string penalty)
+        {
+            Interface = @interface;
+            Penalty = penalty;
+        }
+
+        /// <summary>
+        ///     Set the penalty for a queue member.
+        /// </summary>
+        /// <param name="interface">The interface (tech/name) of the member whose penalty to change.</param>
+        /// <param name="penalty">The new penalty (number) for the member. Must be nonnegative.</param>
+        /// <param name="queue">If specified, only set the penalty for the member of this queue. Otherwise, set the penalty for the member in all queues to which the member belongs.</param>
         public QueuePenaltyAction(string @interface, string penalty, string queue)
         {
             Interface = @interface;
@@ -26,11 +37,20 @@
         {
             get { return "QueuePenalty"; }
         }
-
+        
+        /// <summary>
+        /// The interface (tech/name) of the member whose penalty to change.
+        /// </summary>
         public string Interface { get; set; }
-
+        
+        /// <summary>
+        /// The new penalty (number) for the member. Must be nonnegative.
+        /// </summary>
         public string Penalty { get; set; }
-
+        
+        /// <summary>
+        /// If specified, only set the penalty for the member of this queue. Otherwise, set the penalty for the member in all queues to which the member belongs.
+        /// </summary>
         public string Queue { get; set; }
     }
 }


### PR DESCRIPTION
The `Queue` argument is optional. As seen here: https://wiki.asterisk.org/wiki/display/AST/ManagerAction_QueuePenalty
Added a new constructor without the `queue` parameter.
Added description to parameters and properties.