### PR TITLE
Revert "Clean up on socket initialization error"

### DIFF
--- a/Asterisk.2013/Asterisk.NET/FastAGI/AsteriskFastAGI.cs
+++ b/Asterisk.2013/Asterisk.NET/FastAGI/AsteriskFastAGI.cs
@@ -240,20 +240,6 @@ namespace AsterNET.FastAGI
 #endif
                 throw ex;
             }
-            finally
-            {
-                if (serverSocket != null)
-                {
-                    serverSocket.Close();
-                    serverSocket = null;
-                }
-
-                pool.Shutdown();
-#if LOGGER
-                logger.Info("AGIServer shut down.");
-#endif
-            }
-
 #if LOGGER
             logger.Info("Listening on " + address + ":" + port + ".");
 #endif


### PR DESCRIPTION
Reverts AsterNET/AsterNET#97

Code simply doesn't function as intended. Adding this will close the socket and pool as soon as the AGI Server is started.

Functionally incorrect.