### PR TITLE
Fixed Queue Events

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerJoinEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerJoinEvent.cs
@@ -9,11 +9,7 @@ namespace AsterNET.Manager.Event
 		
 		// "Queue" in QueueEvent.cs
 		
-		/// <summary>
-		///     Get/Set the Caller*ID number of the channel that joined the queue if set.
-		///     If the channel has no caller id set "unknown" is returned.
-		/// </summary>
-		public string CallerIDNum { get; set; }
+		// "CallerId" in JoinEvent.cs
 		
 		// "CallerIdName" in JoinEvent.cs
 		

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerJoinEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerJoinEvent.cs
@@ -1,13 +1,25 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// A QueueCallerJoinEvent is triggered when a channel joins a queue.<br/>
-    /// </summary>
-    public class QueueCallerJoinEvent : QueueEvent
-    {
-        public string Position { get; set; }
-
-        public QueueCallerJoinEvent(ManagerConnection source)
+	/// <summary>
+	/// A QueueCallerJoinEvent is triggered when a channel joins a queue.<br/>
+	/// </summary>
+	public class QueueCallerJoinEvent : JoinEvent
+	{
+		// "Channel" in ManagerEvent.cs
+		
+		// "Queue" in QueueEvent.cs
+		
+		/// <summary>
+		///     Get/Set the Caller*ID number of the channel that joined the queue if set.
+		///     If the channel has no caller id set "unknown" is returned.
+		/// </summary>
+		public string CallerIDNum { get; set; }
+		
+		// "CallerIdName" in JoinEvent.cs
+		
+		// "Position" in JoinEvent.cs
+		
+		public QueueCallerJoinEvent(ManagerConnection source)
 			: base(source)
 		{
 		}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerLeaveEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueCallerLeaveEvent.cs
@@ -1,13 +1,17 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// A QueueCallerLeaveEvent is triggered when a channel leaves a queue.<br/>
-    /// </summary>
-    public class QueueCallerLeaveEvent : QueueEvent
-    {
-        public string Position { get; set; }
-
-        public QueueCallerLeaveEvent(ManagerConnection source)
+	/// <summary>
+	/// A QueueCallerLeaveEvent is triggered when a channel leaves a queue.<br/>
+	/// </summary>
+	public class QueueCallerLeaveEvent : LeaveEvent
+	{
+		// "Channel" in ManagerEvent.cs
+		
+		// "Queue" in QueueEvent.cs
+		
+		// "Count" in QueueEvent.cs
+		
+		public QueueCallerLeaveEvent(ManagerConnection source)
 			: base(source)
 		{
 		}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberAddedEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberAddedEvent.cs
@@ -1,71 +1,19 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// A QueueMemberAddedEvent is triggered when a queue member is added to a queue.<br/>
-    /// It is implemented in apps/app_queue.c.<br/>
-    /// <para>
-    /// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
-    /// </para>
-    /// </summary>
-    public class QueueMemberAddedEvent : AbstractQueueMemberEvent
+	/// <summary>
+	/// A QueueMemberAddedEvent is triggered when a queue member is added to a queue.<br/>
+	/// It is implemented in apps/app_queue.c.<br/>
+	/// <para>
+	/// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
+	/// </para>
+	/// </summary>
+	public class QueueMemberAddedEvent : AbstractQueueMemberEvent
 	{
 		/// <summary>
-		/// Returns the name of the member's interface.<br/>
-		/// E.g. the channel name or agent group.
+		/// Creates a new QueueMemberAddedEvent
 		/// </summary>
-		public new string MemberName { get; set; }
-
-        /// <summary>
-        /// Get/Set if the added member is a dynamic or static queue member.
-        /// "dynamic" if the added member is a dynamic queue member,
-        /// "static" if the added member is a static queue member.
-        /// </summary>
-        public new string Membership { get; set; }
-
-        /// <summary>
-        /// Get/Set the penalty for the added member. When calls are distributed
-        /// members with higher penalties are considered last.
-        /// </summary>
-        public new int Penalty { get; set; }
-
-        /// <summary>
-        /// Get/Set the number of calls answered by the member.
-        /// </summary>
-        public new int CallsTaken { get; set; }
-
-        /// <summary>
-        /// Get/Set the time (in seconds since 01/01/1970) the last successful call answered by the added member was hungup.
-        /// </summary>
-        public new long LastCall { get; set; }
-
-        /// <summary>
-        /// Get/Set the status of this queue member.<br/>
-        /// Valid status codes are:<br/>
-        /// <list type="number" start="0">
-        /// <item>AST_DEVICE_UNKNOWN</item>
-        /// <item>AST_DEVICE_NOT_INUSE</item>
-        /// <item>AST_DEVICE_INUSE</item>
-        /// <item>AST_DEVICE_BUSY</item>
-        /// <item>AST_DEVICE_INVALID</item>
-        /// <item>AST_DEVICE_UNAVAILABLE</item>
-        /// <item>AST_DEVICE_RINGING</item>
-        /// <item>AST_DEVICE_RINGINUSE</item>
-        /// <item>AST_DEVICE_ONHOLD</item>
-        /// </list>
-        /// </summary>
-        public new int Status { get; set; }
-
-        /// <summary>
-        /// Get/Set value if this queue member is paused (not accepting calls).<br/>
-        /// true if this member has been paused or false if not.
-        /// </summary>
-        public new bool Paused { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberAddedEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
-        public QueueMemberAddedEvent(ManagerConnection source)
+		/// <param name="source">ManagerConnection passed through in the event.</param>
+		public QueueMemberAddedEvent(ManagerConnection source)
 			: base(source)
 		{
 		}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberPausedEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberPausedEvent.cs
@@ -2,39 +2,29 @@ using System;
 
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// A QueueMemberPausedEvent is triggered when a queue member is paused or unpaused.<br/>
-    /// It is implemented in apps/app_queue.c.<br/>
-    /// <para>
-    /// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
-    /// <b>Replaced by : </b> <see cref="QueueMemberPauseEvent"/> since <see href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+Documentation" target="_blank" alt="Asterisk 12 wiki docs">Asterisk 12</see>.<br/>
-    /// <b>Removed since : </b> <see href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Documentation" target="_blank" alt="Asterisk 13 wiki docs">Asterisk 13</see>.<br/>
-    /// </para>
-    /// </summary>
+	/// <summary>
+	/// A QueueMemberPausedEvent is triggered when a queue member is paused or unpaused.<br/>
+	/// It is implemented in apps/app_queue.c.<br/>
+	/// <para>
+	/// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
+	/// <b>Replaced by : </b> <see cref="QueueMemberPauseEvent"/> since <see href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+Documentation" target="_blank" alt="Asterisk 12 wiki docs">Asterisk 12</see>.<br/>
+	/// <b>Removed since : </b> <see href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Documentation" target="_blank" alt="Asterisk 13 wiki docs">Asterisk 13</see>.<br/>
+	/// </para>
+	/// </summary>
 	public class QueueMemberPausedEvent : AbstractQueueMemberEvent
 	{
-        /// <summary>
-        /// The reason a member was paused
-        /// </summary>
-        public string Reason { get; set; }
-
-        /// <summary>
-        /// <b>Not Available</b>, use <see cref="QueueMemberPauseEvent"/> instead.
-        /// </summary>
-        public new string PausedReason { get; set; }
-
-        /// <summary>
-        /// <b>Not Available</b>, use <see cref="QueueMemberPauseEvent"/> instead.
-        /// </summary>
-        public new bool InCall { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberPausedEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
-        public QueueMemberPausedEvent(ManagerConnection source)
+		/// <summary>
+		/// The reason a member was paused
+		/// </summary>
+		public string Reason { get; set; }
+		
+		/// <summary>
+		/// Creates a new QueueMemberPausedEvent
+		/// </summary>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
+		public QueueMemberPausedEvent(ManagerConnection source)
 			: base(source)
 		{
-        }
+		}
 	}
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberPenaltyEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberPenaltyEvent.cs
@@ -6,15 +6,10 @@ namespace AsterNET.Manager.Event
 	public class QueueMemberPenaltyEvent : AbstractQueueMemberEvent
 	{
 		/// <summary>
-		/// Get/Set the penalty for the queue location.
+		/// Creates a new QueueMemberPenaltyEvent
 		/// </summary>
-		public new int Penalty { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberPenaltyEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
-        public QueueMemberPenaltyEvent(ManagerConnection source)
+		/// <param name="source">ManagerConnection passed through in the event.</param>
+		public QueueMemberPenaltyEvent(ManagerConnection source)
 			: base(source)
 		{
 		}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberRemovedEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberRemovedEvent.cs
@@ -1,24 +1,18 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// A QueueMemberRemovedEvent is triggered when a queue member is removed from a queue.<br/>
-    /// It is implemented in apps/app_queue.c.<br/>
-    /// <para>
-    /// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
-    /// </para>
-    /// </summary>
-    public class QueueMemberRemovedEvent : AbstractQueueMemberEvent
+	/// <summary>
+	/// A QueueMemberRemovedEvent is triggered when a queue member is removed from a queue.<br/>
+	/// It is implemented in apps/app_queue.c.<br/>
+	/// <para>
+	/// <b>Available since : </b> <see href="http://www.voip-info.org/wiki/view/Asterisk+v1.2" target="_blank" alt="Asterisk 1.2 wiki docs">Asterisk 1.2</see>.<br/>
+	/// </para>
+	/// </summary>
+	public class QueueMemberRemovedEvent : AbstractQueueMemberEvent
 	{
 		/// <summary>
-		/// Returns the name of the member's interface.<br/>
-		/// E.g. the channel name or agent group.
+		/// Creates a new QueueMemberRemovedEvent
 		/// </summary>
-		public new string MemberName { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberRemovedEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
 		public QueueMemberRemovedEvent(ManagerConnection source)
 			: base(source)
 		{

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberRinginuseEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberRinginuseEvent.cs
@@ -1,21 +1,14 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// Raised when a member's ringinuse setting is changed
-    /// </summary>
-    public class QueueMemberRinginuseEvent : AbstractQueueMemberEvent
-    {
-
-        /// <summary>
-        /// Evaluates <see langword="true"/> if Ringinuse,
-        /// <see langword="false"/> if not.<br />
-        /// </summary>
-        public new bool Ringinuse { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberRinginuseEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
+	/// <summary>
+	/// Raised when a member's ringinuse setting is changed
+	/// </summary>
+	public class QueueMemberRinginuseEvent : AbstractQueueMemberEvent
+	{
+		/// <summary>
+		/// Creates a new QueueMemberRinginuseEvent
+		/// </summary>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
 		public QueueMemberRinginuseEvent(ManagerConnection source)
 			: base(source)
 		{

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberStatusEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberStatusEvent.cs
@@ -1,77 +1,14 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// Raised when a Queue member's status has changed
-    /// </summary>
-    public class QueueMemberStatusEvent : AbstractQueueMemberEvent
-    {
-        /// <summary>
-        /// Returns the name of the member's interface.<br/>
-        /// E.g. the channel name or agent group.
-        /// </summary>
-        public new string MemberName { get; set; }
-
-        /// <summary>
-        /// Channel technology or location from which to read device state changes.<br />
-        /// </summary>
-        public new string StateInterface { get; set; }
-
-        /// <summary>
-        /// Get/Set if the added member is a dynamic or static queue member.
-        /// "dynamic" if the added member is a dynamic queue member,
-        /// "static" if the added member is a static queue member.
-        /// </summary>
-        public new string Membership { get; set; }
-
-        /// <summary>
-        /// Get/Set the penalty for the added member. When calls are distributed
-        /// members with higher penalties are considered last.
-        /// </summary>
-        public new int Penalty { get; set; }
-
-        /// <summary>
-        /// Get/Set the number of calls answered by the member.
-        /// </summary>
-        public new int CallsTaken { get; set; }
-
-        /// <summary>
-        /// Get/Set the time (in seconds since 01/01/1970) the last successful call answered by the added member was hungup.
-        /// </summary>
-        public new long LastCall { get; set; }
-
-        /// <summary>
-        /// Evaluates <see langword="true"/> if member is in call,
-        /// <see langword="false"/> after LastCall time is updated.<br />
-        /// </summary>
-        public new bool InCall { get; set; }
-
-        /// <summary>
-        /// Get/Set the status of this queue member.<br/>
-        /// Valid status codes are:<br/>
-        /// <list type="number" start="0">
-        /// <item>AST_DEVICE_UNKNOWN</item>
-        /// <item>AST_DEVICE_NOT_INUSE</item>
-        /// <item>AST_DEVICE_INUSE</item>
-        /// <item>AST_DEVICE_BUSY</item>
-        /// <item>AST_DEVICE_INVALID</item>
-        /// <item>AST_DEVICE_UNAVAILABLE</item>
-        /// <item>AST_DEVICE_RINGING</item>
-        /// <item>AST_DEVICE_RINGINUSE</item>
-        /// <item>AST_DEVICE_ONHOLD</item>
-        /// </list>
-        /// </summary>
-        public new int Status { get; set; }
-
-        /// <summary>
-        /// Get/Set value if this queue member is paused (not accepting calls).<br/>
-        /// true if this member has been paused or false if not.
-        /// </summary>
-        public new bool Paused { get; set; }
-
-        /// <summary>
-        /// Creates a new QueueMemberStatusEvent
-        /// </summary>
-        /// <param name="source">ManagerConnection passed through in the event.</param>
+	/// <summary>
+	/// Raised when a Queue member's status has changed
+	/// </summary>
+	public class QueueMemberStatusEvent : AbstractQueueMemberEvent
+	{
+		/// <summary>
+		/// Creates a new QueueMemberStatusEvent
+		/// </summary>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
 		public QueueMemberStatusEvent(ManagerConnection source)
 			: base(source)
 		{


### PR DESCRIPTION
Made **QueueCallerJoinEvent** inherit from **JoinEvent**.
Made **QueueCallerLeaveEvent** inherit from **LeaveEvent**.

Fixed a bunch of bugs with classes inheriting from **AbstractQueueMemberEvent**.

Fixes #128 
See also #126 