### PR TITLE
Error Waiting to Happen

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Event/ConnectionStateEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/ConnectionStateEvent.cs
@@ -12,7 +12,7 @@ namespace AsterNET.Manager.Event
 		public bool Reconnect
 		{
 			get { return this.reconnect; }
-			set { this.reconnect = true; }
+			set { this.reconnect = value; }
 		}
 
 		public ConnectionStateEvent(ManagerConnection source)


### PR DESCRIPTION
Setting the `Reconnect` property would always result in it becoming true.
While this seem like a neat party trick, it will likely just make someone want to murder you someday.

Changed:
``` cshape
public bool Reconnect
{
    get { return this.reconnect; }
    set { this.reconnect = true; }
}
```
to:
``` cshape
public bool Reconnect
{
    get { return this.reconnect; }
    set { this.reconnect = value; }
}
```