### PR TITLE
AsterNET 1.3 release

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerReader.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerReader.cs
@@ -133,7 +133,7 @@ namespace AsterNET.Manager
 				// \n - because not all dev in Digium use \r\n
 				// .Trim() kill \r
 				lock (((ICollection) lineQueue).SyncRoot)
-					while (!string.IsNullOrEmpty(mrReader.lineBuffer) && (idx = mrReader.lineBuffer.IndexOf("\n")) >= 0)
+					while (!string.IsNullOrEmpty(mrReader.lineBuffer) && (idx = mrReader.lineBuffer.IndexOf('\n')) >= 0)
 					{
 						line = idx > 0 ? mrReader.lineBuffer.Substring(0, idx).Trim() : string.Empty;
 						mrReader.lineBuffer = (idx + 1 < mrReader.lineBuffer.Length

--- a/Asterisk.2013/Asterisk.NET/Properties/AssemblyInfo.cs
+++ b/Asterisk.2013/Asterisk.NET/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: Guid("abe98502-ea83-4b04-98c3-ffe3eabe06b0")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
The [AsterNET-1.x branch](https://github.com/AsterNET/AsterNET/tree/AsterNET-1.x) might be slightly broken after this merge, but mostly just keeping the branch until 2.0 is released.

Just merging the version number into master so that the branches are mostly the same, ish.