### PR TITLE
Synchronize ManagerConnection socket writes to make SendAction threadsafe

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -45,6 +45,7 @@ namespace AsterNET.Manager
         private int pingInterval = 10000;
 
         private object lockSocket = new object();
+        private object lockSocketWrite = new object();
         private object lockHandlers = new object();
 
         private bool enableEvents = true;
@@ -1506,7 +1507,10 @@ namespace AsterNET.Manager
 
         private void sendToAsterisk(string buffer)
         {
-            mrSocket.Write(buffer);
+            lock (lockSocketWrite)
+            {
+                mrSocket.Write(buffer);
+            }
         }
 
         #endregion


### PR DESCRIPTION
We were seeing issues with calling SendAction on a single ManagerConnection accross multiple threads with the messages getting garbled due to simultaneous socket writes. Here is an example where our SetVariable action to set the filepath variable to /mnt/somefile got interrupted by a Redirect action.
```
[Mar 17 17:19:12] VERBOSE[31247][C-00002e8b] pbx.c: Executing [0@playbackfile:1] ControlPlayback("SIP/00002e8b", ""/mnAction: Redirect,0,,,,,,o(0)") in new stack
[Mar 17 17:19:12] WARNING[31247][C-00002e8b] file.c: File /mnAction: Redirect,0,,,,,,o(0) does not exist in any format
```
We tried synchronizing in our code:
```csharp
lock (_managerConnection)
{
    _managerConnection.SendAction(action);
}
```
But this is too high a level to lock at and this caused a huge bottle neck in our application, limiting us to less than 50 concurrent users before everything slowed down as threads waited for each other's commands to be sent to Asterisk. Using the lock of  `mrSocket.Write` in this pull request has allowed us to get back to handling 200 concurrent users without crashes from simultaneous socket writes.