### PR TITLE
Make AGIReply Threadsafe

### DIFF
--- a/Asterisk.2013/Asterisk.NET/FastAGI/AGIChannel.cs
+++ b/Asterisk.2013/Asterisk.NET/FastAGI/AGIChannel.cs
@@ -12,8 +12,6 @@ namespace AsterNET.FastAGI
         private readonly bool _SCHANGUP_CAUSES_EXCEPTION;
         private readonly AGIReader agiReader;
         private readonly AGIWriter agiWriter;
-        private AGIReply agiReply;
-
 
         public AGIChannel(SocketConnection socket, bool SC511_CAUSES_EXCEPTION, bool SCHANGUP_CAUSES_EXCEPTION)
         {
@@ -34,18 +32,10 @@ namespace AsterNET.FastAGI
             _SCHANGUP_CAUSES_EXCEPTION = SCHANGUP_CAUSES_EXCEPTION;
         }
 
-        /// <summary>
-        ///     Get last AGI Reply.
-        /// </summary>
-        public AGIReply LastReply
-        {
-            get { return agiReply; }
-        }
-
         public AGIReply SendCommand(AGICommand command)
         {
             agiWriter.SendCommand(command);
-            agiReply = agiReader.ReadReply();
+            AGIReply agiReply = agiReader.ReadReply();
             int status = agiReply.GetStatus();
             if (status == (int) AGIReplyStatuses.SC_INVALID_OR_UNKNOWN_COMMAND)
                 throw new InvalidOrUnknownCommandException(command.BuildCommand());

--- a/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
+++ b/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
@@ -102,8 +102,8 @@ namespace AsterNET.FastAGI
 		protected internal int GetChannelStatus()
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ChannelStatusCommand());
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ChannelStatusCommand());
+			return lastReply.ResultCode;
 		}
 		#endregion
 
@@ -118,8 +118,8 @@ namespace AsterNET.FastAGI
 		protected internal string GetData(string file)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetDataCommand(file));
-			return channel.LastReply.GetResult();
+			AGIReply lastReply = channel.SendCommand(new Command.GetDataCommand(file));
+			return lastReply.GetResult();
 		}
 		#endregion
 
@@ -137,8 +137,8 @@ namespace AsterNET.FastAGI
 		protected internal string GetData(string file, long timeout)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetDataCommand(file, timeout));
-			return channel.LastReply.GetResult();
+			AGIReply lastReply = channel.SendCommand(new Command.GetDataCommand(file, timeout));
+			return lastReply.GetResult();
 		}
 		#endregion
 
@@ -158,8 +158,8 @@ namespace AsterNET.FastAGI
 		protected internal string GetData(string file, long timeout, int maxDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetDataCommand(file, timeout, maxDigits));
-			return channel.LastReply.GetResult();
+			AGIReply lastReply = channel.SendCommand(new Command.GetDataCommand(file, timeout, maxDigits));
+			return lastReply.GetResult();
 		}
 		#endregion
 
@@ -177,8 +177,8 @@ namespace AsterNET.FastAGI
 		protected internal char GetOption(string file, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -196,8 +196,8 @@ namespace AsterNET.FastAGI
 		protected internal char GetOption(string file, string escapeDigits, int timeout)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits, timeout));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits, timeout));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -210,8 +210,8 @@ namespace AsterNET.FastAGI
 		protected internal int Exec(string application)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ExecCommand(application));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ExecCommand(application));
+			return lastReply.ResultCode;
 		}
 		#endregion
 
@@ -225,8 +225,8 @@ namespace AsterNET.FastAGI
 		protected internal int Exec(string application, string options)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ExecCommand(application, options));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ExecCommand(application, options));
+			return lastReply.ResultCode;
 		}
 		#endregion
 
@@ -291,8 +291,8 @@ namespace AsterNET.FastAGI
 		protected internal char StreamFile(string file, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.StreamFileCommand(file, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.StreamFileCommand(file, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -318,8 +318,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayDigits(string digits, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayDigitsCommand(digits, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayDigitsCommand(digits, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -345,8 +345,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayNumber(string number, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayNumberCommand(number, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayNumberCommand(number, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -372,8 +372,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayPhonetic(string text, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayPhoneticCommand(text, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayPhoneticCommand(text, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -399,8 +399,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayAlpha(string text, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayAlphaCommand(text, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayAlphaCommand(text, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -426,8 +426,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayTime(long time, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayTimeCommand(time, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayTimeCommand(time, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -440,10 +440,10 @@ namespace AsterNET.FastAGI
 		protected internal string GetVariable(string name)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetVariableCommand(name));
-			if (channel.LastReply.ResultCode != 1)
+			AGIReply lastReply = channel.SendCommand(new Command.GetVariableCommand(name));
+			if (lastReply.ResultCode != 1)
 				return null;
-			return channel.LastReply.Extra;
+			return lastReply.Extra;
 		}
 		#endregion
 
@@ -468,8 +468,8 @@ namespace AsterNET.FastAGI
 		protected internal char WaitForDigit(int timeout)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.WaitForDigitCommand(timeout));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.WaitForDigitCommand(timeout));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -484,10 +484,10 @@ namespace AsterNET.FastAGI
 		protected internal string GetFullVariable(string name)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetFullVariableCommand(name));
-			if (channel.LastReply.ResultCode != 1)
+			AGIReply lastReply = channel.SendCommand(new Command.GetFullVariableCommand(name));
+			if (lastReply.ResultCode != 1)
 				return null;
-			return channel.LastReply.Extra;
+			return lastReply.Extra;
 		}
 		#endregion
 
@@ -502,10 +502,10 @@ namespace AsterNET.FastAGI
 		protected internal string GetFullVariable(string name, string channelName)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.GetFullVariableCommand(name, channelName));
-			if (channel.LastReply.ResultCode != 1)
+			AGIReply lastReply = channel.SendCommand(new Command.GetFullVariableCommand(name, channelName));
+			if (lastReply.ResultCode != 1)
 				return null;
-			return channel.LastReply.Extra;
+			return lastReply.Extra;
 		}
 		#endregion
 
@@ -530,8 +530,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayDateTime(long time, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits));
+			return lastReply.ResultCodeAsChar;
 		}
 
 		/// <summary>
@@ -545,8 +545,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayDateTime(long time, string escapeDigits, string format)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits, format));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits, format));
+			return lastReply.ResultCodeAsChar;
 		}
 
 		/// <summary>
@@ -561,8 +561,8 @@ namespace AsterNET.FastAGI
 		protected internal char SayDateTime(long time, string escapeDigits, string format, string timezone)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits, format, timezone));
-			return channel.LastReply.ResultCodeAsChar;
+			AGIReply lastReply = channel.SendCommand(new Command.SayDateTimeCommand(time, escapeDigits, format, timezone));
+			return lastReply.ResultCodeAsChar;
 		}
 		#endregion
 
@@ -576,10 +576,10 @@ namespace AsterNET.FastAGI
 		protected internal string DatabaseGet(string family, string key)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.DatabaseGetCommand(family, key));
-			if (channel.LastReply.ResultCode != 1)
+			AGIReply lastReply = channel.SendCommand(new Command.DatabaseGetCommand(family, key));
+			if (lastReply.ResultCode != 1)
 				return null;
-			return channel.LastReply.Extra;
+			return lastReply.Extra;
 		}
 		#endregion
 
@@ -662,8 +662,8 @@ namespace AsterNET.FastAGI
 		protected internal int RecordFile(string file, string format, string escapeDigits, int timeout)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.RecordFileCommand(file, format, escapeDigits, timeout));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.RecordFileCommand(file, format, escapeDigits, timeout));
+			return lastReply.ResultCode;
 		}
 
 		/// <summary>
@@ -687,8 +687,8 @@ namespace AsterNET.FastAGI
 		protected internal int RecordFile(string file, string format, string escapeDigits, int timeout, int offset, bool beep, int maxSilence)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.RecordFileCommand(file, format, escapeDigits, timeout, offset, beep, maxSilence));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.RecordFileCommand(file, format, escapeDigits, timeout, offset, beep, maxSilence));
+			return lastReply.ResultCode;
 		}
 		#endregion
 
@@ -710,8 +710,8 @@ namespace AsterNET.FastAGI
 		protected internal int ControlStreamFile(string file)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ControlStreamFileCommand(file));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ControlStreamFileCommand(file));
+			return lastReply.ResultCode;
 		}
 		/// <summary>
 		/// Plays the given file, allowing playback to be interrupted by the given
@@ -731,8 +731,8 @@ namespace AsterNET.FastAGI
 		protected internal int ControlStreamFile(string file, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits));
+			return lastReply.ResultCode;
 		}
 		/// <summary>
 		/// Plays the given file, allowing playback to be interrupted by the given
@@ -753,8 +753,8 @@ namespace AsterNET.FastAGI
 		protected internal int ControlStreamFile(string file, string escapeDigits, int offset)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits, offset));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits, offset));
+			return lastReply.ResultCode;
 		}
 		/// <summary>
 		/// Plays the given file, allowing playback to be interrupted by the given
@@ -778,8 +778,8 @@ namespace AsterNET.FastAGI
 		protected internal int ControlStreamFile(string file, string escapeDigits, int offset, string forwardDigit, string rewindDigit, string pauseDigit)
 		{
 			AGIChannel channel = this.Channel;
-			channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits, offset, forwardDigit, rewindDigit, pauseDigit));
-			return channel.LastReply.ResultCode;
+			AGIReply lastReply = channel.SendCommand(new Command.ControlStreamFileCommand(file, escapeDigits, offset, forwardDigit, rewindDigit, pauseDigit));
+			return lastReply.ResultCode;
 		}
 		#endregion
 


### PR DESCRIPTION
`LastReply` is not threadsafe, best to remove it.

Removed `LastReply` from `AGIChannel`.
Instead the `AGIReply` is returned by `SendCommand`.

Fixes #120