### PR TITLE
ReloadEvent causes reconnect

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Action/ModuleLoadAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/ModuleLoadAction.cs
@@ -1,0 +1,33 @@
+namespace AsterNET.Manager.Action
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     The ModuleLoadAction loads/unloads Asterisk modules.
+    /// </summary>
+    public class ModuleLoadAction : ManagerAction
+    {
+        /// <summary>
+        ///     Creates ModuleLoadAction for given module.
+        /// </summary>
+        //// <param name="module">module to load/unload.</param>
+        //// <param name="loadType">loadType parameter can have the following values: load/unload</param>
+        public ModuleLoadAction(string module, string loadType)
+        {
+            Module = module;
+            LoadType = loadType;
+        }
+
+        /// <inheritdoc />
+        public override string Action => "ModuleLoad";
+
+        /// <summary>
+        ///     Get the name of the module.
+        /// </summary>
+        public string Module { get; }
+
+        /// <summary>
+        ///     Get the type of action (load/unload).
+        /// </summary>
+        public string LoadType { get; }
+    }
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/OriginateAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/OriginateAction.cs
@@ -67,6 +67,15 @@ namespace AsterNET.Manager.Action
 
         #endregion
 
+        #region ChannelId
+
+        /// <summary>
+        ///     Get/Set originated channel id
+        /// </summary>
+        public string ChannelId { get; set; }
+
+        #endregion
+
         #region Context 
 
         /// <summary>

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/ReloadAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/ReloadAction.cs
@@ -1,0 +1,26 @@
+namespace AsterNET.Manager.Action
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     The ReloadAction reloads Asterisk modules.
+    /// </summary>
+    public class ReloadAction : ManagerAction
+    {
+        /// <summary>
+        ///     Creates ReloadAction for given module.
+        /// </summary>
+        //// <param name="module">module to reload.</param>
+        public ReloadAction(string module)
+        {
+            Module = module;
+        }
+
+        /// <inheritdoc />
+        public override string Action => "Reload";
+
+        /// <summary>
+        ///     Get the name of the module.
+        /// </summary>
+        public string Module { get; }
+    }
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/UpdateConfigAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/UpdateConfigAction.cs
@@ -114,7 +114,8 @@ namespace AsterNET.Manager.Action
         /// <param name="variable">Variable to work on</param>
         /// <param name="value">Value to work on</param>
         /// <param name="match">Extra match required to match line</param>
-        public void AddCommand(string action, string category, string variable, string value, string match)
+        /// <param name="options">Extra match required to match line</param>
+        public void AddCommand(string action, string category, string variable, string value, string match, string options)
         {
             var i = actionCounter++;
             var index = i.ToString().PadLeft(6, '0');
@@ -133,31 +134,39 @@ namespace AsterNET.Manager.Action
 
             if (!string.IsNullOrEmpty(match))
                 actions.Add("Match-" + index, match);
+
+            if (!string.IsNullOrEmpty(options))
+                Actions.Add("Options-" + index, options);
+        }
+
+        public void AddCommand(string action, string category, string variable, string value, string match)
+        {
+            AddCommand(action, category, variable, value, match, null);
         }
 
         public void AddCommand(string action, string category, string variable, string value)
         {
-            AddCommand(action, category, variable, value, null);
+            AddCommand(action, category, variable, value, null, null);
         }
 
         public void AddCommand(string action, string category, string variable)
         {
-            AddCommand(action, category, variable, null, null);
+            AddCommand(action, category, variable, null, null, null);
         }
 
         public void AddCommand(string action, string category)
         {
-            AddCommand(action, category, null, null, null);
+            AddCommand(action, category, null, null, null, null);
         }
 
         public void AddCommand(string action)
         {
-            AddCommand(action, null, null, null, null);
+            AddCommand(action, null, null, null, null, null);
         }
 
         public void AddCommand()
         {
-            AddCommand(null, null, null, null, null);
+            AddCommand(null, null, null, null, null, null);
         }
 
         #endregion

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -362,9 +362,14 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<ZapShowChannelsEvent> ZapShowChannels;
         /// <summary>
-        /// A ConnectionState is triggered after Connect/Disconnect/Reload/Shutdown events.
+        /// A ConnectionState is triggered after Connect/Disconnect/Shutdown events.
         /// </summary>
         public event EventHandler<ConnectionStateEvent> ConnectionState;
+
+        /// <summary>
+        /// A Reload is triggered after Reload events.
+        /// </summary>
+        public event EventHandler<ReloadEvent> Reload;
 
         /// <summary>
         /// When a variable is set
@@ -573,7 +578,7 @@ namespace AsterNET.Manager
 
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConnectEvent), arg => fireEvent(ConnectionState, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(DisconnectEvent), arg => fireEvent(ConnectionState, arg));
-            Helper.RegisterEventHandler(registeredEventHandlers, typeof(ReloadEvent), arg => fireEvent(ConnectionState, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(ReloadEvent), arg => fireEvent(Reload, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ShutdownEvent), arg => fireEvent(ConnectionState, arg));
 
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(BridgeEvent), arg => fireEvent(Bridge, arg));
@@ -1981,7 +1986,7 @@ namespace AsterNET.Manager
                 fireEvent(e);
                 reconnect(false);
             }
-            else if (!reconnected && reconnectEnable && (e is DisconnectEvent || e is ReloadEvent || e is ShutdownEvent))
+            else if (!reconnected && reconnectEnable && (e is DisconnectEvent || e is ShutdownEvent))
             {
                 ((ConnectionStateEvent)e).Reconnect = true;
                 fireEvent(e);


### PR DESCRIPTION
There is the check in the `ManagerConnection.cs`:

``` C#
else if (!reconnected && reconnectEnable && (e is DisconnectEvent || e is ReloadEvent || e is ShutdownEvent))
{
     ((ConnectionStateEvent)e).Reconnect = true;
     fireEvent(e);
     reconnect(true);
 }
```

It seems that check `e is ReloadEvent` is not needed here. Since the server does not break the connection of manager during reload event. Besides I have some problem with it. My application updates some Asterisk configurations during its work. Library breaks connection after receive reload event. And it takes some time to reconnect. When manager disconnected, application lost some events from Asterisk, and cannot send any actions while reconnecting.

Also:
- Added event `Reload`
- Added `ModuleLoadAction`
- Added `ReloadAction` (supported in Asterisk 13)
- Added parameter `Options` in `UpdateConfigAction` (supported in Asterisk 13)