### PR TITLE
Minor improvements and fixes to Queue Events/Actions and Confbridge Events

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Action/QueuePauseAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/QueuePauseAction.cs
@@ -56,11 +56,13 @@ namespace AsterNET.Manager.Action
         /// <param name="iface">the interface of the member to make unavailable</param>
         /// <param name="queue">the queue the member is made unvailable on</param>
         /// <param name="paused">true to make the member unavailbale, false to make the member available</param>
-        public QueuePauseAction(string iface, string queue, bool paused)
+        /// <param name="reason">the reason for paused when the member is made unavailable</param>
+        public QueuePauseAction(string iface, string queue, bool paused, string reason = null)
         {
             this.Interface = iface;
             this.Queue = queue;
             this.Paused = paused;
+            this.Reason = reason;
         }
 
         /// <summary>

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/ConfbridgeMuteEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/ConfbridgeMuteEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AsterNET.Manager.Event
+{
+    public class ConfbridgeMuteEvent : AbstractConfbridgeEvent
+    {
+        public ConfbridgeMuteEvent(ManagerConnection source)
+            : base(source)
+        {
+        }
+    }
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/ConfbridgeUnmuteEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/ConfbridgeUnmuteEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AsterNET.Manager.Event
+{
+    public class ConfbridgeUnmuteEvent : AbstractConfbridgeEvent
+    {
+        public ConfbridgeUnmuteEvent(ManagerConnection source)
+            : base(source)
+        {
+        }
+    }
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/JoinEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/JoinEvent.cs
@@ -15,7 +15,7 @@ namespace AsterNET.Manager.Event
         ///     Get/Set the Caller*ID number of the channel that joined the queue if set.
         ///     If the channel has no caller id set "unknown" is returned.
         /// </summary>
-        public string CallerId { get; set; }
+        public string CallerIdNum { get; set; }
 
         /// <summary>
         ///     Get/Set the Caller*ID name of the channel that joined the queue if set.

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/QueueMemberEvent.cs
@@ -18,6 +18,7 @@ namespace AsterNET.Manager.Event
 		private bool paused;
 		private string name;
         private bool incall;
+		private string pausedReason;
 
         /// <summary>
         /// Get/Set the name of the queue member.
@@ -135,6 +136,14 @@ namespace AsterNET.Manager.Event
             get { return this.incall; }
             set { this.incall = value; }
         }
+		/// <summary>
+		/// Paused reason if the queue member is paused
+		/// </summary>
+		public string PausedReason
+		{
+			get { return this.pausedReason; }
+			set { this.pausedReason = value; }
+		}
 
         public QueueMemberEvent(ManagerConnection source)
 			: base(source)

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -408,6 +408,16 @@ namespace AsterNET.Manager
         public event EventHandler<ConfbridgeTalkingEvent> ConfbridgeTalking;
 
         /// <summary>
+        /// This event is sent when a Confbridge participant mutes.
+        /// </summary>
+        public event EventHandler<ConfbridgeMuteEvent> ConfbridgeMute;
+
+        /// <summary>
+        /// This event is sent when a Confbridge participant unmutes.
+        /// </summary>
+        public event EventHandler<ConfbridgeUnmuteEvent> ConfbridgeUnmute;
+
+        /// <summary>
         /// 
         /// </summary>
         public event EventHandler<FailedACLEvent> FailedACL;
@@ -596,6 +606,8 @@ namespace AsterNET.Manager
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConfbridgeLeaveEvent), arg => fireEvent(ConfbridgeLeave, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConfbridgeEndEvent), arg => fireEvent(ConfbridgeEnd, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConfbridgeTalkingEvent), arg => fireEvent(ConfbridgeTalking, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConfbridgeMuteEvent), arg => fireEvent(ConfbridgeMute, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(ConfbridgeUnmuteEvent), arg => fireEvent(ConfbridgeUnmute, arg));
 
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(FailedACLEvent), arg => fireEvent(FailedACL, arg));
 


### PR DESCRIPTION
1. Pass unavailable reason when creating QueuePauseAction
2. QueueMember JoinEvent provides CallerIdNum instead of CallerId
3. QueueMemberEvent now retrieves paused reason
4. Added ConfbridgeMuteEvent and ConfbridgeUnmuteEvent classes so they can be triggered