### PR TITLE
Changed the type of the result field of the BlindTransferEvent class

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/Event/BlindTransferEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/BlindTransferEvent.cs
@@ -6,7 +6,7 @@ namespace AsterNET.Manager.Event
 {
 	public class BlindTransferEvent : ManagerEvent
 	{
-        public bool Result { get; set; }
+        public string Result { get; set; }
         public string TransfererChannel { get; set; }
         public string TransfererChannelState { get; set; }
         public string TransfererChannelStatedesc { get; set; }


### PR DESCRIPTION
The BlindTransferEvent event changed the type of the Result field type from bool to string.
Because, in the astersik documentation, this field is of type string.