### PR TITLE
Fixed multiple entries with same key

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Helper.cs
+++ b/Asterisk.2013/Asterisk.NET/Helper.cs
@@ -647,7 +647,7 @@ namespace AsterNET
             {
                 string name = line.Substring(0, delimiterIndex).ToLower(CultureInfo).Trim();
                 string val = line.Substring(delimiterIndex + 1).Trim();
-                if (list.ContainsKey(name))
+                if (list.Contains(name))
                     list[name] += Environment.NewLine + val;
                 else if (val == "<null>")
                     list[name] = null;

--- a/Asterisk.2013/Asterisk.NET/Helper.cs
+++ b/Asterisk.2013/Asterisk.NET/Helper.cs
@@ -647,7 +647,9 @@ namespace AsterNET
             {
                 string name = line.Substring(0, delimiterIndex).ToLower(CultureInfo).Trim();
                 string val = line.Substring(delimiterIndex + 1).Trim();
-                if (val == "<null>")
+                if (list.ContainsKey(name))
+                    list[name] += Environment.NewLine + val;
+                else if (val == "<null>")
                     list[name] = null;
                 else
                     list[name] = val;


### PR DESCRIPTION
Should the issue if the reply from the asterisk server has multiple entries with the same key.

I am going out on a limb here and assuming that there won't be cases where any of the duplicate entries will be `<null>`.

Fixes #233