### PR TITLE
Operation is not supported on this platform

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -2049,7 +2049,7 @@ namespace AsterNET.Manager
         {
             if (enableEvents && internalEvent != null)
                 if (UseASyncEvents)
-                    internalEvent.BeginInvoke(this, e, new AsyncCallback(eventComplete), null);
+                    Task.Run(() => internalEvent.Invoke(this, e)).ContinueWith(eventComplete);
                 else
                     internalEvent.Invoke(this, e);
         }


### PR DESCRIPTION
I was getting a PlatformNotSupported exception with .Net Core 3.1 saying "Operation is not supported on this platform". This code change fixes that and maintains functionality.