### PR TITLE
Fix Version Regex to handle with version with Output prefixed

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Common.cs
+++ b/Asterisk.2013/Asterisk.NET/Common.cs
@@ -18,8 +18,8 @@ namespace AsterNET
         /// <summary>Line separator</summary>
         public const string LINE_SEPARATOR = "\r\n";
 
-        public static Regex ASTERISK_VERSION = new Regex( "^Asterisk\\s+\\D*([0-9]+\\.[0-9]+\\.[0-9]+|[1-9][0-9]-r[0-9]+|[0-9]+\\.[0-9]+-cert[0-9]).*$",
-                    RegexOptions.Compiled | RegexOptions.IgnoreCase );
+        public static Regex ASTERISK_VERSION = new Regex("^(?:Output: ){0,1}Asterisk\\s+\\D*([0-9]+\\.[0-9]+\\.[0-9]+|[1-9][0-9]-r[0-9]+|[0-9]+\\.[0-9]+-cert[0-9]).*$",
+                          RegexOptions.Compiled | RegexOptions.IgnoreCase );
 
         public static Regex SHOW_VERSION_FILES_PATTERN = new Regex("^([\\S]+)\\s+Revision: ([0-9\\.]+)");
         public static char[] RESPONSE_KEY_VALUE_SEPARATOR = {':'};


### PR DESCRIPTION
The version determining regex does not handle output prefixed with "Output: " correctly. Thus altered to allow determining the version if prefixed with "Output: ". 

Example of line variable in https://github.com/AsterNET/AsterNET/blob/c23d932609ad0ae3893f0532fb59ed0d5da7cbc2/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs#L1037 

"Output: Asterisk 16.5.1 built by root @ hostname on a x86_64 running Linux on 2019-10-09 13:19:54 UTC"

