### PR TITLE
Get Option Return string

### DIFF
--- a/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
+++ b/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
@@ -178,7 +178,7 @@ namespace AsterNET.FastAGI
 		{
 			AGIChannel channel = this.Channel;
 			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits));
-			return lastReply.ResultCodeAsChar;
+			return lastReply.GetResult();
 		}
 		#endregion
 
@@ -197,7 +197,7 @@ namespace AsterNET.FastAGI
 		{
 			AGIChannel channel = this.Channel;
 			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits, timeout));
-			return lastReply.ResultCodeAsChar;
+			return lastReply.GetResult();
 		}
 		#endregion
 

--- a/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
+++ b/Asterisk.2013/Asterisk.NET/FastAGI/AGIScript.cs
@@ -174,7 +174,7 @@ namespace AsterNET.FastAGI
 		/// <param name="file">the name of the file to stream, must not include extension.</param>
 		/// <param name="escapeDigits">contains the digits that the user is expected to press.</param>
 		/// <returns> the DTMF digit pressed or 0x0 if none was pressed.</returns>
-		protected internal char GetOption(string file, string escapeDigits)
+		protected internal string GetOption(string file, string escapeDigits)
 		{
 			AGIChannel channel = this.Channel;
 			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits));
@@ -193,7 +193,7 @@ namespace AsterNET.FastAGI
 		/// <param name="escapeDigits">contains the digits that the user is expected to press.</param>
 		/// <param name="timeout">the timeout in seconds to wait if none of the defined esacpe digits was presses while streaming.</param>
 		/// <returns> the DTMF digit pressed or 0x0 if none was pressed.</returns>
-		protected internal char GetOption(string file, string escapeDigits, int timeout)
+		protected internal string GetOption(string file, string escapeDigits, int timeout)
 		{
 			AGIChannel channel = this.Channel;
 			AGIReply lastReply = channel.SendCommand(new Command.GetOptionCommand(file, escapeDigits, timeout));


### PR DESCRIPTION
Change GetOption AGI command to return the result code as a string instead of char and fixes issue of not getting -1 on error