### PR TITLE
Core show channels action and minor improvements

### DIFF
--- a/Asterisk.2013/Asterisk.NET/AsterNET.csproj
+++ b/Asterisk.2013/Asterisk.NET/AsterNET.csproj
@@ -12,6 +12,21 @@
     <PackageReleaseNotes>Please see: https://github.com/AsterNET/AsterNET/commits/master</PackageReleaseNotes>
     <Configurations>Debug;Release;Travis</Configurations>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+  </PropertyGroup>
+
+
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Asterisk.2013/Asterisk.NET/Helper.cs
+++ b/Asterisk.2013/Asterisk.NET/Helper.cs
@@ -10,881 +10,895 @@ using AsterNET.Manager.Response;
 
 namespace AsterNET
 {
-    internal class Helper
-    {
-        private static CultureInfo defaultCulture;
+	internal class Helper
+	{
+		private static CultureInfo defaultCulture;
 #if LOGGER
-        private static readonly Logger logger = Logger.Instance();
+		private static readonly Logger logger = Logger.Instance();
 #endif
 
-        #region CultureInfo 
-
-        internal static CultureInfo CultureInfo
-        {
-            get
-            {
-                if (defaultCulture == null)
-                    defaultCulture = CultureInfo.GetCultureInfo("en");
-                return defaultCulture;
-            }
-        }
-
-        #endregion
-
-        #region ToHexString(sbyte[]) 
-
-        /// <summary> The hex digits used to build a hex string representation of a byte array.</summary>
-        internal static readonly char[] hexChar =
-        {
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
-            'e', 'f'
-        };
-
-        /// <summary>
-        ///     Converts a byte array to a hex string representing it. The hex digits are lower case.
-        /// </summary>
-        /// <param name="b">the byte array to convert</param>
-        /// <returns> the hex representation of b</returns>
-        internal static string ToHexString(sbyte[] b)
-        {
-            var sb = new StringBuilder(b.Length*2);
-            for (int i = 0; i < b.Length; i++)
-            {
-                sb.Append(hexChar[URShift((b[i] & 0xf0), 4)]);
-                sb.Append(hexChar[b[i] & 0x0f]);
-            }
-            return sb.ToString();
-        }
-
-        #endregion
-
-        #region GetInternalActionId(actionId) 
-
-        internal static string GetInternalActionId(string actionId)
-        {
-            if (string.IsNullOrEmpty(actionId))
-                return string.Empty;
-            int delimiterIndex = actionId.IndexOf(Common.INTERNAL_ACTION_ID_DELIMITER);
-            if (delimiterIndex > 0)
-                return actionId.Substring(0, delimiterIndex).Trim();
-            return string.Empty;
-        }
-
-        #endregion
-
-        #region StripInternalActionId(actionId) 
-
-        internal static string StripInternalActionId(string actionId)
-        {
-            if (string.IsNullOrEmpty(actionId))
-                return string.Empty;
-            int delimiterIndex = actionId.IndexOf(Common.INTERNAL_ACTION_ID_DELIMITER);
-            if (delimiterIndex > 0)
-            {
-                if (actionId.Length > delimiterIndex + 1)
-                    return actionId.Substring(delimiterIndex + 1).Trim();
-                return actionId.Substring(0, delimiterIndex).Trim();
-            }
-            return string.Empty;
-        }
-
-        #endregion
-
-        #region IsTrue(string) 
-
-        /// <summary>
-        ///     Checks if a String represents true or false according to Asterisk's logic.<br />
-        ///     The original implementation is util.c is as follows:
-        /// </summary>
-        /// <param name="s">the String to check for true.</param>
-        /// <returns>
-        ///     true if s represents true,
-        ///     false otherwise.
-        /// </returns>
-        internal static bool IsTrue(string s)
-        {
-            if (s == null || s.Length == 0)
-                return false;
-            string sx = s.ToLower(CultureInfo);
-            if (sx == "yes" || sx == "true" || sx == "y" || sx == "t" || sx == "1" || sx == "on")
-                return true;
-            return false;
-        }
-
-        #endregion
-
-        #region URShift(...) 
-
-        /// <summary>
-        ///     Performs an unsigned bitwise right shift with the specified number
-        /// </summary>
-        /// <param name="number">Number to operate on</param>
-        /// <param name="bits">Ammount of bits to shift</param>
-        /// <returns>The resulting number from the shift operation</returns>
-        internal static int URShift(int number, int bits)
-        {
-            if (number >= 0)
-                return number >> bits;
-            return (number >> bits) + (2 << ~bits);
-        }
-
-        /// <summary>
-        ///     Performs an unsigned bitwise right shift with the specified number
-        /// </summary>
-        /// <param name="number">Number to operate on</param>
-        /// <param name="bits">Ammount of bits to shift</param>
-        /// <returns>The resulting number from the shift operation</returns>
-        internal static int URShift(int number, long bits)
-        {
-            return URShift(number, (int) bits);
-        }
-
-        /// <summary>
-        ///     Performs an unsigned bitwise right shift with the specified number
-        /// </summary>
-        /// <param name="number">Number to operate on</param>
-        /// <param name="bits">Ammount of bits to shift</param>
-        /// <returns>The resulting number from the shift operation</returns>
-        internal static long URShift(long number, int bits)
-        {
-            if (number >= 0)
-                return number >> bits;
-            return (number >> bits) + (2L << ~bits);
-        }
-
-        /// <summary>
-        ///     Performs an unsigned bitwise right shift with the specified number
-        /// </summary>
-        /// <param name="number">Number to operate on</param>
-        /// <param name="bits">Ammount of bits to shift</param>
-        /// <returns>The resulting number from the shift operation</returns>
-        internal static long URShift(long number, long bits)
-        {
-            return URShift(number, (int) bits);
-        }
-
-        #endregion
-
-        #region ToArray(ICollection c, object[] objects) 
-
-        /// <summary>
-        ///     Obtains an array containing all the elements of the collection.
-        /// </summary>
-        /// <param name="objects">The array into which the elements of the collection will be stored.</param>
-        /// <param name="c"></param>
-        /// <returns>The array containing all the elements of the collection.</returns>
-        internal static object[] ToArray(ICollection c, object[] objects)
-        {
-            int index = 0;
-
-            Type type = objects.GetType().GetElementType();
-            var objs = (object[]) Array.CreateInstance(type, c.Count);
-
-            IEnumerator e = c.GetEnumerator();
-
-            while (e.MoveNext())
-                objs[index++] = e.Current;
-
-            //If objects is smaller than c then do not return the new array in the parameter
-            if (objects.Length >= c.Count)
-                objs.CopyTo(objects, 0);
-
-            return objs;
-        }
-
-        #endregion
-
-        #region ParseVariables(Dictionary<string, string> dictionary, string variables, char[] delim)
-
-        /// <summary>
-        ///     Parse variable(s) string to dictionary.
-        /// </summary>
-        /// <param name="dictionary"></param>
-        /// <param name="variables">variable(a) string</param>
-        /// <param name="delim">variable pairs delimiter</param>
-        /// <returns></returns>
-        internal static Dictionary<string, string> ParseVariables(Dictionary<string, string> dictionary,
-            string variables, char[] delim)
-        {
-            if (dictionary == null)
-                dictionary = new Dictionary<string, string>();
-            else
-                dictionary.Clear();
-
-            if (string.IsNullOrEmpty(variables))
-                return dictionary;
-            string[] vars = variables.Split(delim);
-            int idx;
-            string vname, vval;
-            foreach (var var in vars)
-            {
-                idx = var.IndexOf('=');
-                if (idx > 0)
-                {
-                    vname = var.Substring(0, idx);
-                    vval = var.Substring(idx + 1);
-                }
-                else
-                {
-                    vname = var;
-                    vval = string.Empty;
-                }
-                dictionary.Add(vname, vval);
-            }
-            return dictionary;
-        }
-
-        #endregion
-
-        #region JoinVariables(IDictionary dictionary, string delim) 
-
-        /// <summary>
-        ///     Join variables dictionary to string.
-        /// </summary>
-        /// <param name="dictionary"></param>
-        /// <param name="delim"></param>
-        /// <param name="delimKeyValue"></param>
-        /// <returns></returns>
-        internal static string JoinVariables(IDictionary dictionary, char[] delim, string delimKeyValue)
-        {
-            return JoinVariables(dictionary, new string(delim), delimKeyValue);
-        }
-
-        internal static string JoinVariables(IDictionary dictionary, string delim, string delimKeyValue)
-        {
-            if (dictionary == null)
-                return string.Empty;
-            var sb = new StringBuilder();
-            foreach (DictionaryEntry var in dictionary)
-            {
-                if (sb.Length > 0)
-                    sb.Append(delim);
-                sb.Append(string.Concat(var.Key, delimKeyValue, var.Value));
-            }
-            return sb.ToString();
-        }
-
-        #endregion
-
-        #region GetMillisecondsFrom(DateTime start) 
-
-        internal static long GetMillisecondsFrom(DateTime start)
-        {
-            TimeSpan ts = DateTime.Now - start;
-            return (long) ts.TotalMilliseconds;
-        }
-
-        #endregion
-
-        #region ParseString(string val) 
-
-        internal static object ParseString(string val)
-        {
-            if (val == "none")
-                return string.Empty;
-            return val;
-        }
-
-        #endregion
-
-        #region GetGetters(class) 
-
-        /// <summary>
-        ///     Returns a Map of getter methods of the given class.<br />
-        ///     The key of the map contains the name of the attribute that can be accessed by the getter, the
-        ///     value the getter itself . A method is considered a getter if its name starts with "get",
-        ///     it is declared internal and takes no arguments.
-        /// </summary>
-        /// <param name="clazz">the class to return the getters for</param>
-        /// <returns> a Map of attributes and their accessor methods (getters)</returns>
-        internal static Dictionary<string, MethodInfo> GetGetters(Type clazz)
-        {
-            string name;
-            string methodName;
-            MethodInfo method;
-
-            var accessors = new Dictionary<string, MethodInfo>();
-            MethodInfo[] methods = clazz.GetMethods();
-
-            for (int i = 0; i < methods.Length; i++)
-            {
-                method = methods[i];
-                methodName = method.Name;
-
-                // skip not "get..." methods and  skip methods with != 0 parameters
-                if (!methodName.StartsWith("get_") || method.GetParameters().Length != 0)
-                    continue;
-
-                name = methodName.Substring(4);
-                if (name.Length == 0)
-                    continue;
-                accessors[name] = method;
-            }
-            return accessors;
-        }
-
-        #endregion
-
-        #region GetSetters(Type clazz) 
-
-        /// <summary>
-        ///     Returns a Map of setter methods of the given class.<br />
-        ///     The key of the map contains the name of the attribute that can be accessed by the setter, the
-        ///     value the setter itself. A method is considered a setter if its name starts with "set",
-        ///     it is declared internal and takes no arguments.
-        /// </summary>
-        /// <param name="clazz">the class to return the setters for</param>
-        /// <returns> a Map of attributes and their accessor methods (setters)</returns>
-        internal static IDictionary GetSetters(Type clazz)
-        {
-            IDictionary accessors = new Hashtable();
-            MethodInfo[] methods = clazz.GetMethods();
-            string name;
-            string methodName;
-            MethodInfo method;
-
-            for (int i = 0; i < methods.Length; i++)
-            {
-                method = methods[i];
-                methodName = method.Name;
-                // skip not "set..." methods and  skip methods with != 1 parameters
-                if (!methodName.StartsWith("set_") || method.GetParameters().Length != 1)
-                    continue;
-                name = methodName.Substring("set_".Length).ToLower(CultureInfo);
-                if (name.Length == 0) continue;
-                accessors[name] = method;
-            }
-            return accessors;
-        }
-
-        #endregion
-
-        #region ToString(object obj) 
-
-        /// <summary>
-        ///     Convert object with all properties to string
-        /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
-        internal static string ToString(object obj)
-        {
-            object value;
-            var sb = new StringBuilder(obj.GetType().Name, 1024);
-            sb.Append(" {");
-            string strValue;
-            IDictionary getters = GetGetters(obj.GetType());
-            bool notFirst = false;
-            var arrays = new List<MethodInfo>();
-            // First step - all values properties (not a list)
-            foreach (string name in getters.Keys)
-            {
-                var getter = (MethodInfo) getters[name];
-                Type propType = getter.ReturnType;
-                if (propType == typeof (object))
-                    continue;
-                if (
-                    !(propType == typeof (string) || propType == typeof (bool) || propType == typeof (double) ||
-                      propType == typeof (DateTime) || propType == typeof (int) || propType == typeof (long)))
-                {
-                    string propTypeName = propType.Name;
-                    if (propTypeName.StartsWith("Dictionary") || propTypeName.StartsWith("List"))
-                    {
-                        arrays.Add(getter);
-                    }
-                    continue;
-                }
-
-                try
-                {
-                    value = getter.Invoke(obj, new object[] {});
-                }
-                catch
-                {
-                    continue;
-                }
-
-                if (value == null)
-                    continue;
-                if (value is string)
-                {
-                    strValue = (string) value;
-                    if (strValue.Length == 0)
-                        continue;
-                }
-                else if (value is bool)
-                {
-                    strValue = ((bool) value ? "true" : "false");
-                }
-                else if (value is double)
-                {
-                    var d = (double) value;
-                    if (d == 0.0)
-                        continue;
-                    strValue = d.ToString();
-                }
-                else if (value is DateTime)
-                {
-                    var dt = (DateTime) value;
-                    if (dt == DateTime.MinValue)
-                        continue;
-                    strValue = dt.ToLongTimeString();
-                }
-                else if (value is int)
-                {
-                    var i = (int) value;
-                    if (i == 0)
-                        continue;
-                    strValue = i.ToString();
-                }
-                else if (value is long)
-                {
-                    var l = (long) value;
-                    if (l == 0)
-                        continue;
-                    strValue = l.ToString();
-                }
-                else
-                    strValue = value.ToString();
-
-                if (notFirst)
-                    sb.Append("; ");
-                notFirst = true;
-                sb.Append(string.Concat(getter.Name.Substring(4), ":", strValue));
-            }
-
-            // Second step - all lists
-            foreach (var getter in arrays)
-            {
-                value = null;
-                try
-                {
-                    value = getter.Invoke(obj, new object[] {});
-                }
-                catch
-                {
-                    continue;
-                }
-                if (value == null)
-                    continue;
-
-                #region List 
-
-                IList list;
-                if (value is IList && (list = (IList) value).Count > 0)
-                {
-                    if (notFirst)
-                        sb.Append("; ");
-                    notFirst = true;
-                    sb.Append(getter.Name.Substring(4));
-                    sb.Append(":[");
-                    bool notFirst2 = false;
-                    foreach (var o in list)
-                    {
-                        if (notFirst2)
-                            sb.Append("; ");
-                        notFirst2 = true;
-                        sb.Append(o);
-                    }
-                    sb.Append("]");
-                }
-                    #endregion
-
-                    #region IDictionary 
-                if (value is IDictionary && ((IDictionary) value).Count > 0)
-                {
-                    if (notFirst)
-                        sb.Append("; ");
-                    notFirst = true;
-                    sb.Append(getter.Name.Substring(4));
-                    sb.Append(":[");
-                    bool notFirst2 = false;
-                    foreach (var key in ((IDictionary) value).Keys)
-                    {
-                        object o = ((IDictionary) value)[key];
-                        if (notFirst2)
-                            sb.Append("; ");
-                        notFirst2 = true;
-                        sb.Append(string.Concat(key, ":", o));
-                    }
-                    sb.Append("]");
-                }
-
-                #endregion
-            }
-
-            sb.Append("}");
-            return sb.ToString();
-        }
-
-        #endregion
-
-        #region SetAttributes(object evt, IDictionary attributes) 
-
-        internal static void SetAttributes(IParseSupport o, Dictionary<string, string> attributes)
-        {
-            Type dataType;
-            object val;
-
-            // Preparse attributes
-            attributes = o.ParseSpecial(attributes);
-
-            IDictionary setters = GetSetters(o.GetType());
-            MethodInfo setter;
-            foreach (var name in attributes.Keys)
-            {
-                if (name == "event")
-                    continue;
-
-                if (name == "source")
-                    setter = (MethodInfo) setters["src"];
-                else
-                    setter = (MethodInfo) setters[stripIllegalCharacters(name)];
-
-                if (setter == null)
-                {
-                    // No setter found to key, try general parser
-                    if (!o.Parse(name, attributes[name]))
-                    {
+		#region CultureInfo 
+
+		internal static CultureInfo CultureInfo
+		{
+			get
+			{
+				if (defaultCulture == null)
+					defaultCulture = CultureInfo.GetCultureInfo("en");
+				return defaultCulture;
+			}
+		}
+
+		#endregion
+
+		#region ToHexString(sbyte[]) 
+
+		/// <summary> The hex digits used to build a hex string representation of a byte array.</summary>
+		internal static readonly char[] hexChar =
+		{
+			'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
+			'e', 'f'
+		};
+
+		/// <summary>
+		///     Converts a byte array to a hex string representing it. The hex digits are lower case.
+		/// </summary>
+		/// <param name="b">the byte array to convert</param>
+		/// <returns> the hex representation of b</returns>
+		internal static string ToHexString(sbyte[] b)
+		{
+			var sb = new StringBuilder(b.Length * 2);
+			for (int i = 0; i < b.Length; i++)
+			{
+				sb.Append(hexChar[URShift((b[i] & 0xf0), 4)]);
+				sb.Append(hexChar[b[i] & 0x0f]);
+			}
+			return sb.ToString();
+		}
+
+		#endregion
+
+		#region GetInternalActionId(actionId) 
+
+		internal static string GetInternalActionId(string actionId)
+		{
+			if (string.IsNullOrEmpty(actionId))
+				return string.Empty;
+			int delimiterIndex = actionId.IndexOf(Common.INTERNAL_ACTION_ID_DELIMITER);
+			if (delimiterIndex > 0)
+				return actionId.Substring(0, delimiterIndex).Trim();
+			return string.Empty;
+		}
+
+		#endregion
+
+		#region StripInternalActionId(actionId) 
+
+		internal static string StripInternalActionId(string actionId)
+		{
+			if (string.IsNullOrEmpty(actionId))
+				return string.Empty;
+			int delimiterIndex = actionId.IndexOf(Common.INTERNAL_ACTION_ID_DELIMITER);
+			if (delimiterIndex > 0)
+			{
+				if (actionId.Length > delimiterIndex + 1)
+					return actionId.Substring(delimiterIndex + 1).Trim();
+				return actionId.Substring(0, delimiterIndex).Trim();
+			}
+			return string.Empty;
+		}
+
+		#endregion
+
+		#region IsTrue(string) 
+
+		/// <summary>
+		///     Checks if a String represents true or false according to Asterisk's logic.<br />
+		///     The original implementation is util.c is as follows:
+		/// </summary>
+		/// <param name="s">the String to check for true.</param>
+		/// <returns>
+		///     true if s represents true,
+		///     false otherwise.
+		/// </returns>
+		internal static bool IsTrue(string s)
+		{
+			if (s == null || s.Length == 0)
+				return false;
+			string sx = s.ToLower(CultureInfo);
+			if (sx == "yes" || sx == "true" || sx == "y" || sx == "t" || sx == "1" || sx == "on")
+				return true;
+			return false;
+		}
+
+		#endregion
+
+		#region URShift(...) 
+
+		/// <summary>
+		///     Performs an unsigned bitwise right shift with the specified number
+		/// </summary>
+		/// <param name="number">Number to operate on</param>
+		/// <param name="bits">Ammount of bits to shift</param>
+		/// <returns>The resulting number from the shift operation</returns>
+		internal static int URShift(int number, int bits)
+		{
+			if (number >= 0)
+				return number >> bits;
+			return (number >> bits) + (2 << ~bits);
+		}
+
+		/// <summary>
+		///     Performs an unsigned bitwise right shift with the specified number
+		/// </summary>
+		/// <param name="number">Number to operate on</param>
+		/// <param name="bits">Ammount of bits to shift</param>
+		/// <returns>The resulting number from the shift operation</returns>
+		internal static int URShift(int number, long bits)
+		{
+			return URShift(number, (int)bits);
+		}
+
+		/// <summary>
+		///     Performs an unsigned bitwise right shift with the specified number
+		/// </summary>
+		/// <param name="number">Number to operate on</param>
+		/// <param name="bits">Ammount of bits to shift</param>
+		/// <returns>The resulting number from the shift operation</returns>
+		internal static long URShift(long number, int bits)
+		{
+			if (number >= 0)
+				return number >> bits;
+			return (number >> bits) + (2L << ~bits);
+		}
+
+		/// <summary>
+		///     Performs an unsigned bitwise right shift with the specified number
+		/// </summary>
+		/// <param name="number">Number to operate on</param>
+		/// <param name="bits">Ammount of bits to shift</param>
+		/// <returns>The resulting number from the shift operation</returns>
+		internal static long URShift(long number, long bits)
+		{
+			return URShift(number, (int)bits);
+		}
+
+		#endregion
+
+		#region ToArray(ICollection c, object[] objects) 
+
+		/// <summary>
+		///     Obtains an array containing all the elements of the collection.
+		/// </summary>
+		/// <param name="objects">The array into which the elements of the collection will be stored.</param>
+		/// <param name="c"></param>
+		/// <returns>The array containing all the elements of the collection.</returns>
+		internal static object[] ToArray(ICollection c, object[] objects)
+		{
+			int index = 0;
+
+			Type type = objects.GetType().GetElementType();
+			var objs = (object[])Array.CreateInstance(type, c.Count);
+
+			IEnumerator e = c.GetEnumerator();
+
+			while (e.MoveNext())
+				objs[index++] = e.Current;
+
+			//If objects is smaller than c then do not return the new array in the parameter
+			if (objects.Length >= c.Count)
+				objs.CopyTo(objects, 0);
+
+			return objs;
+		}
+
+		#endregion
+
+		#region ParseVariables(Dictionary<string, string> dictionary, string variables, char[] delim)
+
+		/// <summary>
+		///     Parse variable(s) string to dictionary.
+		/// </summary>
+		/// <param name="dictionary"></param>
+		/// <param name="variables">variable(a) string</param>
+		/// <param name="delim">variable pairs delimiter</param>
+		/// <returns></returns>
+		internal static Dictionary<string, string> ParseVariables(Dictionary<string, string> dictionary,
+			string variables, char[] delim)
+		{
+			if (dictionary == null)
+				dictionary = new Dictionary<string, string>();
+			else
+				dictionary.Clear();
+
+			if (string.IsNullOrEmpty(variables))
+				return dictionary;
+			string[] vars = variables.Split(delim);
+			int idx;
+			string vname, vval;
+			foreach (var var in vars)
+			{
+				idx = var.IndexOf('=');
+				if (idx > 0)
+				{
+					vname = var.Substring(0, idx);
+					vval = var.Substring(idx + 1);
+				}
+				else
+				{
+					vname = var;
+					vval = string.Empty;
+				}
+				dictionary.Add(vname, vval);
+			}
+			return dictionary;
+		}
+
+		#endregion
+
+		#region JoinVariables(IDictionary dictionary, string delim) 
+
+		/// <summary>
+		///     Join variables dictionary to string.
+		/// </summary>
+		/// <param name="dictionary"></param>
+		/// <param name="delim"></param>
+		/// <param name="delimKeyValue"></param>
+		/// <returns></returns>
+		internal static string JoinVariables(IDictionary dictionary, char[] delim, string delimKeyValue)
+		{
+			return JoinVariables(dictionary, new string(delim), delimKeyValue);
+		}
+
+		internal static string JoinVariables(IDictionary dictionary, string delim, string delimKeyValue)
+		{
+			if (dictionary == null)
+				return string.Empty;
+			var sb = new StringBuilder();
+			foreach (DictionaryEntry var in dictionary)
+			{
+				if (sb.Length > 0)
+					sb.Append(delim);
+				sb.Append(string.Concat(var.Key, delimKeyValue, var.Value));
+			}
+			return sb.ToString();
+		}
+
+		#endregion
+
+		#region GetMillisecondsFrom(DateTime start) 
+
+		internal static long GetMillisecondsFrom(DateTime start)
+		{
+			TimeSpan ts = DateTime.Now - start;
+			return (long)ts.TotalMilliseconds;
+		}
+
+		#endregion
+
+		#region ParseString(string val) 
+
+		internal static object ParseString(string val)
+		{
+			if (val == "none")
+				return string.Empty;
+			return val;
+		}
+
+		#endregion
+
+		#region GetGetters(class) 
+
+		/// <summary>
+		///     Returns a Map of getter methods of the given class.<br />
+		///     The key of the map contains the name of the attribute that can be accessed by the getter, the
+		///     value the getter itself . A method is considered a getter if its name starts with "get",
+		///     it is declared internal and takes no arguments.
+		/// </summary>
+		/// <param name="clazz">the class to return the getters for</param>
+		/// <returns> a Map of attributes and their accessor methods (getters)</returns>
+		internal static Dictionary<string, MethodInfo> GetGetters(Type clazz)
+		{
+			string name;
+			string methodName;
+			MethodInfo method;
+
+			var accessors = new Dictionary<string, MethodInfo>();
+			MethodInfo[] methods = clazz.GetMethods();
+
+			for (int i = 0; i < methods.Length; i++)
+			{
+				method = methods[i];
+				methodName = method.Name;
+
+				// skip not "get..." methods and  skip methods with != 0 parameters
+				if (!methodName.StartsWith("get_") || method.GetParameters().Length != 0)
+					continue;
+
+				name = methodName.Substring(4);
+				if (name.Length == 0)
+					continue;
+				accessors[name] = method;
+			}
+			return accessors;
+		}
+
+		#endregion
+
+		#region GetSetters(Type clazz) 
+
+		/// <summary>
+		///     Returns a Map of setter methods of the given class.<br />
+		///     The key of the map contains the name of the attribute that can be accessed by the setter, the
+		///     value the setter itself. A method is considered a setter if its name starts with "set",
+		///     it is declared internal and takes no arguments.
+		/// </summary>
+		/// <param name="clazz">the class to return the setters for</param>
+		/// <returns> a Map of attributes and their accessor methods (setters)</returns>
+		internal static IDictionary GetSetters(Type clazz)
+		{
+			IDictionary accessors = new Hashtable();
+			MethodInfo[] methods = clazz.GetMethods();
+			string name;
+			string methodName;
+			MethodInfo method;
+
+			for (int i = 0; i < methods.Length; i++)
+			{
+				method = methods[i];
+				methodName = method.Name;
+				// skip not "set..." methods and  skip methods with != 1 parameters
+				if (!methodName.StartsWith("set_") || method.GetParameters().Length != 1)
+					continue;
+				name = methodName.Substring("set_".Length).ToLower(CultureInfo);
+				if (name.Length == 0)
+					continue;
+				accessors[name] = method;
+			}
+			return accessors;
+		}
+
+		#endregion
+
+		#region ToString(object obj) 
+
+		/// <summary>
+		///     Convert object with all properties to string
+		/// </summary>
+		/// <param name="obj"></param>
+		/// <returns></returns>
+		internal static string ToString(object obj)
+		{
+			object value;
+			var sb = new StringBuilder(obj.GetType().Name, 1024);
+			sb.Append(" {");
+			string strValue;
+			IDictionary getters = GetGetters(obj.GetType());
+			bool notFirst = false;
+			var arrays = new List<MethodInfo>();
+			// First step - all values properties (not a list)
+			foreach (string name in getters.Keys)
+			{
+				var getter = (MethodInfo)getters[name];
+				Type propType = getter.ReturnType;
+				if (propType == typeof(object))
+					continue;
+				if (
+					!(propType == typeof(string) || propType == typeof(bool) || propType == typeof(double) ||
+					  propType == typeof(DateTime) || propType == typeof(int) || propType == typeof(long) ||
+					  propType == typeof(TimeSpan) || propType == typeof(Guid)))
+				{
+					string propTypeName = propType.Name;
+					if (propTypeName.StartsWith("Dictionary") || propTypeName.StartsWith("List"))
+					{
+						arrays.Add(getter);
+					}
+					continue;
+				}
+
+				try
+				{
+					value = getter.Invoke(obj, new object[] { });
+				}
+				catch
+				{
+					continue;
+				}
+
+				if (value == null)
+					continue;
+				if (value is string)
+				{
+					strValue = (string)value;
+					if (strValue.Length == 0)
+						continue;
+				}
+				else if (value is bool)
+				{
+					strValue = ((bool)value ? "true" : "false");
+				}
+				else if (value is double)
+				{
+					var d = (double)value;
+					if (d == 0.0)
+						continue;
+					strValue = d.ToString();
+				}
+				else if (value is DateTime)
+				{
+					var dt = (DateTime)value;
+					if (dt == DateTime.MinValue)
+						continue;
+					strValue = dt.ToLongTimeString();
+				}
+				else if (value is int)
+				{
+					var i = (int)value;
+					if (i == 0)
+						continue;
+					strValue = i.ToString();
+				}
+				else if (value is long)
+				{
+					var l = (long)value;
+					if (l == 0)
+						continue;
+					strValue = l.ToString();
+				}
+				else
+					strValue = value.ToString();
+
+				if (notFirst)
+					sb.Append("; ");
+				notFirst = true;
+				sb.Append(string.Concat(getter.Name.Substring(4), ":", strValue));
+			}
+
+			// Second step - all lists
+			foreach (var getter in arrays)
+			{
+				value = null;
+				try
+				{
+					value = getter.Invoke(obj, new object[] { });
+				}
+				catch
+				{
+					continue;
+				}
+				if (value == null)
+					continue;
+
+				#region List 
+
+				IList list;
+				if (value is IList && (list = (IList)value).Count > 0)
+				{
+					if (notFirst)
+						sb.Append("; ");
+					notFirst = true;
+					sb.Append(getter.Name.Substring(4));
+					sb.Append(":[");
+					bool notFirst2 = false;
+					foreach (var o in list)
+					{
+						if (notFirst2)
+							sb.Append("; ");
+						notFirst2 = true;
+						sb.Append(o);
+					}
+					sb.Append("]");
+				}
+				#endregion
+
+				#region IDictionary 
+				if (value is IDictionary && ((IDictionary)value).Count > 0)
+				{
+					if (notFirst)
+						sb.Append("; ");
+					notFirst = true;
+					sb.Append(getter.Name.Substring(4));
+					sb.Append(":[");
+					bool notFirst2 = false;
+					foreach (var key in ((IDictionary)value).Keys)
+					{
+						object o = ((IDictionary)value)[key];
+						if (notFirst2)
+							sb.Append("; ");
+						notFirst2 = true;
+						sb.Append(string.Concat(key, ":", o));
+					}
+					sb.Append("]");
+				}
+
+				#endregion
+			}
+
+			sb.Append("}");
+			return sb.ToString();
+		}
+
+		#endregion
+
+		#region SetAttributes(object evt, IDictionary attributes) 
+
+		internal static void SetAttributes(IParseSupport o, Dictionary<string, string> attributes)
+		{
+			Type dataType;
+			object val;
+
+			// Preparse attributes
+			attributes = o.ParseSpecial(attributes);
+
+			IDictionary setters = GetSetters(o.GetType());
+			MethodInfo setter;
+			foreach (var name in attributes.Keys)
+			{
+				if (name == "event")
+					continue;
+
+				if (name == "source")
+					setter = (MethodInfo)setters["src"];
+				else
+					setter = (MethodInfo)setters[stripIllegalCharacters(name)];
+
+				if (setter == null)
+				{
+					// No setter found to key, try general parser
+					if (!o.Parse(name, attributes[name]))
+					{
 #if LOGGER
-                        logger.Error("Unable to set property '" + name + "' on " + o.GetType() + ": no setter");
+						logger.Error("Unable to set property '" + name + "' on " + o.GetType() + ": no setter");
 #endif
-                        throw new ManagerException("Parse error key '" + name + "' on " + o.GetType());
-                    }
-                }
-                else
-                {
-                    dataType = (setter.GetParameters()[0]).ParameterType;
-                    if (dataType == typeof (bool))
-                        val = IsTrue(attributes[name]);
-                    else if (dataType == typeof (string))
-                        val = ParseString(attributes[name]);
-                    else if (dataType == typeof (Int32))
-                    {
-                        Int32 v = 0;
-                        Int32.TryParse(attributes[name], out v);
-                        val = v;
-                    }
-                    else if (dataType == typeof (Int64))
-                    {
-                        Int64 v = 0;
-                        Int64.TryParse(attributes[name], out v);
-                        val = v;
-                    }
-                    else if (dataType == typeof (double))
-                    {
-                        Double v = 0.0;
-                        Double.TryParse(attributes[name], NumberStyles.AllowDecimalPoint, Common.CultureInfoEn, out v);
-                        val = v;
-                    }
-                    else if (dataType == typeof (decimal))
-                    {
-                        Decimal v = 0;
-                        Decimal.TryParse(attributes[name], NumberStyles.AllowDecimalPoint, Common.CultureInfoEn, out v);
-                        val = v;
-                    }
-                    else if (dataType.IsEnum)
-                    {
-                        try
-                        {
-                            val = Convert.ChangeType(Enum.Parse(dataType, attributes[name], true), dataType);
-                        }
-                        catch (Exception ex)
-                        {
+						throw new ManagerException("Parse error key '" + name + "' on " + o.GetType());
+					}
+				}
+				else
+				{
+					dataType = (setter.GetParameters()[0]).ParameterType;
+					if (dataType == typeof(bool))
+						val = IsTrue(attributes[name]);
+					else if (dataType == typeof(string))
+						val = ParseString(attributes[name]);
+					else if (dataType == typeof(Int32))
+					{
+						Int32 v = 0;
+						Int32.TryParse(attributes[name], out v);
+						val = v;
+					}
+					else if (dataType == typeof(Int64))
+					{
+						Int64 v = 0;
+						Int64.TryParse(attributes[name], out v);
+						val = v;
+					}
+					else if (dataType == typeof(double))
+					{
+						Double v = 0.0;
+						Double.TryParse(attributes[name], NumberStyles.AllowDecimalPoint, Common.CultureInfoEn, out v);
+						val = v;
+					}
+					else if (dataType == typeof(decimal))
+					{
+						Decimal v = 0;
+						Decimal.TryParse(attributes[name], NumberStyles.AllowDecimalPoint, Common.CultureInfoEn, out v);
+						val = v;
+					}
+					else if (dataType == typeof(TimeSpan))
+					{
+						TimeSpan v = TimeSpan.Zero;
+						TimeSpan.TryParseExact(attributes[name], "hh\\:mm\\:ss", Common.CultureInfoEn, out v);
+						val = v;
+					}
+					else if (dataType == typeof(Guid))
+					{
+						Guid v = Guid.Empty;
+						Guid.TryParse(attributes[name], out v);
+						val = v;
+					}
+					else if (dataType.IsEnum)
+					{
+						try
+						{
+							val = Convert.ChangeType(Enum.Parse(dataType, attributes[name], true), dataType);
+						}
+						catch (Exception ex)
+						{
 #if LOGGER
-                            logger.Error(
-                                "Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " +
-                                o.GetType() + " to required enum type " + dataType, ex);
-                            continue;
+							logger.Error(
+								"Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " +
+								o.GetType() + " to required enum type " + dataType, ex);
+							continue;
 #else
 							throw new ManagerException("Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " + o.GetType() + " to required enum type " + dataType, ex); 
 #endif
-                        }
-                    }
-                    else
-                    {
-                        try
-                        {
-                            ConstructorInfo constructor = dataType.GetConstructor(new[] {typeof (string)});
-                            val = constructor.Invoke(new object[] {attributes[name]});
-                        }
-                        catch (Exception ex)
-                        {
+						}
+					}
+					else
+					{
+						try
+						{
+							ConstructorInfo constructor = dataType.GetConstructor(new[] { typeof(string) });
+							val = constructor.Invoke(new object[] { attributes[name] });
+						}
+						catch (Exception ex)
+						{
 #if LOGGER
-                            logger.Error(
-                                "Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " +
-                                o.GetType() + " to required type " + dataType, ex);
-                            continue;
+							logger.Error(
+								"Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " +
+								o.GetType() + " to required type " + dataType, ex);
+							continue;
 #else
 							throw new ManagerException("Unable to convert value '" + attributes[name] + "' of property '" + name + "' on " + o.GetType() + " to required type " + dataType, ex);
 #endif
-                        }
-                    }
+						}
+					}
 
-                    try
-                    {
-                        setter.Invoke(o, new[] {val});
-                    }
-                    catch (Exception ex)
-                    {
+					try
+					{
+						setter.Invoke(o, new[] { val });
+					}
+					catch (Exception ex)
+					{
 #if LOGGER
-                        logger.Error("Unable to set property '" + name + "' on " + o.GetType(), ex);
+						logger.Error("Unable to set property '" + name + "' on " + o.GetType(), ex);
 #else
 						throw new ManagerException("Unable to set property '" + name + "' on " + o.GetType(), ex);
 #endif
-                    }
-                }
-            }
-        }
+					}
+				}
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region AddKeyValue(IDictionary list, string line) 
+		#region AddKeyValue(IDictionary list, string line) 
 
-        internal static void AddKeyValue(IDictionary list, string line)
-        {
-            int delimiterIndex = line.IndexOf(":");
-            if (delimiterIndex > 0 && line.Length > delimiterIndex + 1)
-            {
-                string name = line.Substring(0, delimiterIndex).ToLower(CultureInfo).Trim();
-                string val = line.Substring(delimiterIndex + 1).Trim();
-                if (list.Contains(name))
-                    list[name] += Environment.NewLine + val;
-                else if (val == "<null>")
-                    list[name] = null;
-                else
-                    list[name] = val;
-            }
-        }
+		internal static void AddKeyValue(IDictionary list, string line)
+		{
+			int delimiterIndex = line.IndexOf(":");
+			if (delimiterIndex > 0 && line.Length > delimiterIndex + 1)
+			{
+				string name = line.Substring(0, delimiterIndex).ToLower(CultureInfo).Trim();
+				string val = line.Substring(delimiterIndex + 1).Trim();
+				if (list.Contains(name))
+					list[name] += Environment.NewLine + val;
+				else if (val == "<null>")
+					list[name] = null;
+				else
+					list[name] = val;
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region stripIllegalCharacters(string s) 
+		#region stripIllegalCharacters(string s) 
 
-        /// <summary>
-        ///     Strips all illegal charaters from the given lower case string.
-        /// </summary>
-        /// <param name="s">the original string</param>
-        /// <returns>the string with all illegal characters stripped</returns>
-        private static string stripIllegalCharacters(string s)
-        {
-            char c;
-            bool needsStrip = false;
+		/// <summary>
+		///     Strips all illegal charaters from the given lower case string.
+		/// </summary>
+		/// <param name="s">the original string</param>
+		/// <returns>the string with all illegal characters stripped</returns>
+		private static string stripIllegalCharacters(string s)
+		{
+			char c;
+			bool needsStrip = false;
 
-            if (string.IsNullOrEmpty(s))
-                return null;
+			if (string.IsNullOrEmpty(s))
+				return null;
 
-            for (int i = 0; i < s.Length; i++)
-            {
-                c = s[i];
-                if (c >= '0' && c <= '9')
-                    continue;
-                if (c >= 'a' && c <= 'z')
-                    continue;
-                if (c >= 'A' && c <= 'Z')
-                    continue;
-                needsStrip = true;
-                break;
-            }
+			for (int i = 0; i < s.Length; i++)
+			{
+				c = s[i];
+				if (c >= '0' && c <= '9')
+					continue;
+				if (c >= 'a' && c <= 'z')
+					continue;
+				if (c >= 'A' && c <= 'Z')
+					continue;
+				needsStrip = true;
+				break;
+			}
 
-            if (!needsStrip)
-                return s;
+			if (!needsStrip)
+				return s;
 
-            var sb = new StringBuilder(s.Length);
-            for (int i = 0; i < s.Length; i++)
-            {
-                c = s[i];
-                if (c >= '0' && c <= '9')
-                    sb.Append(c);
-                else if (c >= 'a' && c <= 'z')
-                    sb.Append(c);
-                else if (c >= 'A' && c <= 'Z')
-                    sb.Append(c);
-            }
+			var sb = new StringBuilder(s.Length);
+			for (int i = 0; i < s.Length; i++)
+			{
+				c = s[i];
+				if (c >= '0' && c <= '9')
+					sb.Append(c);
+				else if (c >= 'a' && c <= 'z')
+					sb.Append(c);
+				else if (c >= 'A' && c <= 'Z')
+					sb.Append(c);
+			}
 
-            return sb.ToString();
-        }
+			return sb.ToString();
+		}
 
-        #endregion
+		#endregion
 
-        #region BuildResponse(IDictionary attributes) 
+		#region BuildResponse(IDictionary attributes) 
 
-        /// <summary>
-        ///     Constructs an instance of ManagerResponse based on a map of attributes.
-        /// </summary>
-        /// <param name="attributes">the attributes and their values. The keys of this map must be all lower case.</param>
-        /// <returns>the response with the given attributes.</returns>
-        internal static ManagerResponse BuildResponse(Dictionary<string, string> attributes)
-        {
-            ManagerResponse response;
+		/// <summary>
+		///     Constructs an instance of ManagerResponse based on a map of attributes.
+		/// </summary>
+		/// <param name="attributes">the attributes and their values. The keys of this map must be all lower case.</param>
+		/// <returns>the response with the given attributes.</returns>
+		internal static ManagerResponse BuildResponse(Dictionary<string, string> attributes)
+		{
+			ManagerResponse response;
 
-            string responseType = attributes["response"].ToLower(CultureInfo);
+			string responseType = attributes["response"].ToLower(CultureInfo);
 
-            // Determine type
-            if (responseType == "error")
-                response = new ManagerError();
-            else if (attributes.ContainsKey("challenge"))
-                response = new ChallengeResponse();
-            else if (attributes.ContainsKey("mailbox") && attributes.ContainsKey("waiting"))
-                response = new MailboxStatusResponse();
-            else if (attributes.ContainsKey("mailbox") && attributes.ContainsKey("newmessages") &&
-                     attributes.ContainsKey("oldmessages"))
-                response = new MailboxCountResponse();
-            else if (attributes.ContainsKey("exten") && attributes.ContainsKey("context") &&
-                     attributes.ContainsKey("hint") && attributes.ContainsKey("status"))
-                response = new ExtensionStateResponse();
-            else
-                response = new ManagerResponse();
+			// Determine type
+			if (responseType == "error")
+				response = new ManagerError();
+			else if (attributes.ContainsKey("challenge"))
+				response = new ChallengeResponse();
+			else if (attributes.ContainsKey("mailbox") && attributes.ContainsKey("waiting"))
+				response = new MailboxStatusResponse();
+			else if (attributes.ContainsKey("mailbox") && attributes.ContainsKey("newmessages") &&
+					 attributes.ContainsKey("oldmessages"))
+				response = new MailboxCountResponse();
+			else if (attributes.ContainsKey("exten") && attributes.ContainsKey("context") &&
+					 attributes.ContainsKey("hint") && attributes.ContainsKey("status"))
+				response = new ExtensionStateResponse();
+			else
+				response = new ManagerResponse();
 
-            SetAttributes(response, attributes);
-            return response;
-        }
+			SetAttributes(response, attributes);
+			return response;
+		}
 
-        #endregion
+		#endregion
 
-        #region BuildEvent(Hashtable list, object source, IDictionary attributes) 
+		#region BuildEvent(Hashtable list, object source, IDictionary attributes) 
 
-        /// <summary>
-        ///     Builds the event based on the given map of attributes and the registered event classes.
-        /// </summary>
-        /// <param name="source">source attribute for the event</param>
-        /// <param name="list"></param>
-        /// <param name="attributes">map containing event attributes</param>
-        /// <returns>a concrete instance of ManagerEvent or null if no event class was registered for the event type.</returns>
-        internal static ManagerEvent BuildEvent(IDictionary<int, ConstructorInfo> list, ManagerConnection source,
-            Dictionary<string, string> attributes)
-        {
-            ManagerEvent e;
-            string eventType;
-            ConstructorInfo constructor = null;
-            int hash, hashEvent;
+		/// <summary>
+		///     Builds the event based on the given map of attributes and the registered event classes.
+		/// </summary>
+		/// <param name="source">source attribute for the event</param>
+		/// <param name="list"></param>
+		/// <param name="attributes">map containing event attributes</param>
+		/// <returns>a concrete instance of ManagerEvent or null if no event class was registered for the event type.</returns>
+		internal static ManagerEvent BuildEvent(IDictionary<int, ConstructorInfo> list, ManagerConnection source,
+			Dictionary<string, string> attributes)
+		{
+			ManagerEvent e;
+			string eventType;
+			ConstructorInfo constructor = null;
+			int hash, hashEvent;
 
-            eventType = attributes["event"].ToLower(CultureInfo);
-            // Remove Event tail from event name (ex. JabberEvent)
-            if (eventType.EndsWith("event"))
-                eventType = eventType.Substring(0, eventType.Length - 5);
-            hashEvent = eventType.GetHashCode();
+			eventType = attributes["event"].ToLower(CultureInfo);
+			// Remove Event tail from event name (ex. JabberEvent)
+			if (eventType.EndsWith("event"))
+				eventType = eventType.Substring(0, eventType.Length - 5);
+			hashEvent = eventType.GetHashCode();
 
-            if (eventType == "user")
-            {
-                string userevent = attributes["userevent"].ToLower(CultureInfo);
-                hash = string.Concat(eventType, userevent).GetHashCode();
-                if (list.ContainsKey(hash))
-                    constructor = list[hash];
-                else
-                    constructor = list[hashEvent];
-            }
-            else if (list.ContainsKey(hashEvent))
-                constructor = list[hashEvent];
+			if (eventType == "user")
+			{
+				string userevent = attributes["userevent"].ToLower(CultureInfo);
+				hash = string.Concat(eventType, userevent).GetHashCode();
+				if (list.ContainsKey(hash))
+					constructor = list[hash];
+				else
+					constructor = list[hashEvent];
+			}
+			else if (list.ContainsKey(hashEvent))
+				constructor = list[hashEvent];
 
-            if (constructor == null)
-                e = new UnknownEvent(source);
-            else
-            {
-                try
-                {
-                    e = (ManagerEvent) constructor.Invoke(new object[] {source});
-                }
-                catch (Exception ex)
-                {
+			if (constructor == null)
+				e = new UnknownEvent(source);
+			else
+			{
+				try
+				{
+					e = (ManagerEvent)constructor.Invoke(new object[] { source });
+				}
+				catch (Exception ex)
+				{
 #if LOGGER
-                    logger.Error("Unable to create new instance of " + eventType, ex);
-                    return null;
+					logger.Error("Unable to create new instance of " + eventType, ex);
+					return null;
 #else
 					throw ex;
 #endif
-                }
-            }
+				}
+			}
 
-            SetAttributes(e, attributes);
+			SetAttributes(e, attributes);
 
-            // ResponseEvents are sent in response to a ManagerAction if the
-            // response contains lots of data. They include the actionId of
-            // the corresponding ManagerAction.
-            if (e is ResponseEvent)
-            {
-                var responseEvent = (ResponseEvent) e;
-                string actionId = responseEvent.ActionId;
-                if (actionId != null)
-                {
-                    responseEvent.ActionId = StripInternalActionId(actionId);
-                    responseEvent.InternalActionId = GetInternalActionId(actionId);
-                }
-            }
+			// ResponseEvents are sent in response to a ManagerAction if the
+			// response contains lots of data. They include the actionId of
+			// the corresponding ManagerAction.
+			if (e is ResponseEvent)
+			{
+				var responseEvent = (ResponseEvent)e;
+				string actionId = responseEvent.ActionId;
+				if (actionId != null)
+				{
+					responseEvent.ActionId = StripInternalActionId(actionId);
+					responseEvent.InternalActionId = GetInternalActionId(actionId);
+				}
+			}
 
-            return e;
-        }
+			return e;
+		}
 
-        #endregion
+		#endregion
 
-        #region RegisterBuiltinEventClasses(Hashtable list) 
+		#region RegisterBuiltinEventClasses(Hashtable list) 
 
-        /// <summary>
-        ///     Register buildin Event classes
-        /// </summary>
-        /// <param name="list"></param>
-        internal static void RegisterBuiltinEventClasses(Dictionary<int, ConstructorInfo> list)
-        {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            Type manager = typeof (ManagerEvent);
-            foreach (var type in assembly.GetTypes())
-                if (type.IsPublic && !type.IsAbstract && manager.IsAssignableFrom(type))
-                    RegisterEventClass(list, type);
-        }
+		/// <summary>
+		///     Register buildin Event classes
+		/// </summary>
+		/// <param name="list"></param>
+		internal static void RegisterBuiltinEventClasses(Dictionary<int, ConstructorInfo> list)
+		{
+			Assembly assembly = Assembly.GetExecutingAssembly();
+			Type manager = typeof(ManagerEvent);
+			foreach (var type in assembly.GetTypes())
+				if (type.IsPublic && !type.IsAbstract && manager.IsAssignableFrom(type))
+					RegisterEventClass(list, type);
+		}
 
-        #endregion
+		#endregion
 
-        #region RegisterEventClass(Dictionary<string, ConstructorInfo> list, Type clazz)
+		#region RegisterEventClass(Dictionary<string, ConstructorInfo> list, Type clazz)
 
-        internal static void RegisterEventClass(Dictionary<int, ConstructorInfo> list, Type clazz)
-        {
-            // Ignore all abstract classes
-            // Class not derived from ManagerEvent
-            if (clazz.IsAbstract || !typeof (ManagerEvent).IsAssignableFrom(clazz))
-                return;
+		internal static void RegisterEventClass(Dictionary<int, ConstructorInfo> list, Type clazz)
+		{
+			// Ignore all abstract classes
+			// Class not derived from ManagerEvent
+			if (clazz.IsAbstract || !typeof(ManagerEvent).IsAssignableFrom(clazz))
+				return;
 
-            string eventType = clazz.Name.ToLower(CultureInfo);
+			string eventType = clazz.Name.ToLower(CultureInfo);
 
-            // Remove "event" at the end (if presents)
-            if (eventType.EndsWith("event"))
-                eventType = eventType.Substring(0, eventType.Length - 5);
+			// Remove "event" at the end (if presents)
+			if (eventType.EndsWith("event"))
+				eventType = eventType.Substring(0, eventType.Length - 5);
 
-            // If assignable from UserEvent and no "userevent" at the start - add "userevent" to beginning
-            if (typeof (UserEvent).IsAssignableFrom(clazz) && !eventType.StartsWith("user"))
-                eventType = "user" + eventType;
+			// If assignable from UserEvent and no "userevent" at the start - add "userevent" to beginning
+			if (typeof(UserEvent).IsAssignableFrom(clazz) && !eventType.StartsWith("user"))
+				eventType = "user" + eventType;
 
-            int hash = eventType.GetHashCode();
-            if (list.ContainsKey(hash))
-                return;
+			int hash = eventType.GetHashCode();
+			if (list.ContainsKey(hash))
+				return;
 
-            ConstructorInfo constructor = null;
-            try
-            {
-                constructor = clazz.GetConstructor(new[] {typeof (ManagerConnection)});
-            }
-            catch (MethodAccessException ex)
-            {
-                throw new ArgumentException("RegisterEventClass : " + clazz + " has no usable constructor.", ex);
-            }
+			ConstructorInfo constructor = null;
+			try
+			{
+				constructor = clazz.GetConstructor(new[] { typeof(ManagerConnection) });
+			}
+			catch (MethodAccessException ex)
+			{
+				throw new ArgumentException("RegisterEventClass : " + clazz + " has no usable constructor.", ex);
+			}
 
-            if (constructor != null && constructor.IsPublic)
-                list.Add(hash, constructor);
-            else
-                throw new ArgumentException("RegisterEventClass : " + clazz + " has no public default constructor");
-        }
+			if (constructor != null && constructor.IsPublic)
+				list.Add(hash, constructor);
+			else
+				throw new ArgumentException("RegisterEventClass : " + clazz + " has no public default constructor");
+		}
 
-        #endregion
+		#endregion
 
-        #region RegisterEventHandler(Dictionary<int, int> list, int index, Type eventType) 
+		#region RegisterEventHandler(Dictionary<int, int> list, int index, Type eventType) 
 
-        internal static void RegisterEventHandler(Dictionary<int, Func<ManagerEvent, bool>> list, Type eventType, Func<ManagerEvent, bool> action)
-        {
-            var eventTypeName = eventType.Name;
-            int eventHash = eventTypeName.GetHashCode();
-            if (list.ContainsKey(eventHash))
-                throw new ArgumentException("Event class already registered : " + eventTypeName);
-            list.Add(eventHash, action);
-        }
+		internal static void RegisterEventHandler(Dictionary<int, Func<ManagerEvent, bool>> list, Type eventType, Func<ManagerEvent, bool> action)
+		{
+			var eventTypeName = eventType.Name;
+			int eventHash = eventTypeName.GetHashCode();
+			if (list.ContainsKey(eventHash))
+				throw new ArgumentException("Event class already registered : " + eventTypeName);
+			list.Add(eventHash, action);
+		}
 
-        #endregion
-    }
+		#endregion
+	}
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
@@ -1,10 +1,26 @@
-﻿namespace AsterNET.Manager.Action
+﻿using AsterNET.Manager.Event;
+using System;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace AsterNET.Manager.Action
 {
-    public class CoreShowChannelsAction : ManagerAction
-    {
-        public override string Action
-        {
-            get { return "CoreShowChannels"; }
-        }
-    }
+	public class CoreShowChannelsAction : ManagerActionEvent
+	{
+		#region Action
+
+		/// <summary>
+		///     Get the name of this action, i.e. "CoreShowChannels".
+		/// </summary>
+		public override string Action
+		{
+			get { return "CoreShowChannels"; }
+		}
+
+		#endregion
+
+		public override Type ActionCompleteEventClass()
+		{
+			return typeof(CoreShowChannelsCompleteEvent);
+		}
+	}
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
@@ -6,17 +6,13 @@ namespace AsterNET.Manager.Action
 {
 	public class CoreShowChannelsAction : ManagerActionEvent
 	{
-		#region Action
-
 		/// <summary>
-		///     Get the name of this action, i.e. "CoreShowChannels".
+		///     Get the name of this action "CoreShowChannels".
 		/// </summary>
 		public override string Action
 		{
 			get { return "CoreShowChannels"; }
 		}
-
-		#endregion
 
 		public override Type ActionCompleteEventClass()
 		{

--- a/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Action/CoreShowChannelsAction.cs
@@ -4,19 +4,19 @@ using static System.Net.Mime.MediaTypeNames;
 
 namespace AsterNET.Manager.Action
 {
-	public class CoreShowChannelsAction : ManagerActionEvent
-	{
-		/// <summary>
-		///     Get the name of this action "CoreShowChannels".
-		/// </summary>
-		public override string Action
-		{
-			get { return "CoreShowChannels"; }
-		}
+    public class CoreShowChannelsAction : ManagerActionEvent
+    {
+        /// <summary>
+        ///     Get the name of this action "CoreShowChannels".
+        /// </summary>
+        public override string Action
+        {
+            get { return "CoreShowChannels"; }
+        }
 
-		public override Type ActionCompleteEventClass()
-		{
-			return typeof(CoreShowChannelsCompleteEvent);
-		}
-	}
+        public override Type ActionCompleteEventClass()
+        {
+            return typeof(CoreShowChannelsCompleteEvent);
+        }
+    }
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
@@ -1,105 +1,105 @@
 namespace AsterNET.Manager.Event
 {
-	/// <summary>
-	/// Abstract base class providing common properties for HangupEvent, NewChannelEvent and NewStateEvent.
-	/// </summary>
-	public abstract class AbstractChannelEvent : ResponseEvent
-	{
-		private string channelState;
-		private string channelStateDesc;
-		private string callerId;
-		private string callerIdNum;
-		private string callerIdName;
-		private string accountCode;
-		private string state;
-		private string connectedLineNum;
-		private string connectedLineName;
+    /// <summary>
+    /// Abstract base class providing common properties for HangupEvent, NewChannelEvent and NewStateEvent.
+    /// </summary>
+    public abstract class AbstractChannelEvent : ResponseEvent
+    {
+        private string channelState;
+        private string channelStateDesc;
+        private string callerId;
+        private string callerIdNum;
+        private string callerIdName;
+        private string accountCode;
+        private string state;
+        private string connectedLineNum;
+        private string connectedLineName;
 
-		/// <summary>
-		/// Get/Set Channel State
-		/// </summary>
-		public string ChannelState
-		{
-			get { return this.channelState; }
-			set { this.channelState = value; }
-		}
+        /// <summary>
+        /// Get/Set Channel State
+        /// </summary>
+        public string ChannelState
+        {
+            get { return this.channelState; }
+            set { this.channelState = value; }
+        }
 
-		/// <summary>
-		/// Get/Set Channel State Description
-		/// </summary>
-		public string ChannelStateDesc
-		{
-			get { return this.channelStateDesc; }
-			set { this.channelStateDesc = value; }
-		}
+        /// <summary>
+        /// Get/Set Channel State Description
+        /// </summary>
+        public string ChannelStateDesc
+        {
+            get { return this.channelStateDesc; }
+            set { this.channelStateDesc = value; }
+        }
 
-		/// <summary>
-		/// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
-		/// </summary>
-		public string CallerId
-		{
-			get { return callerId; }
-			set { this.callerId = value; }
-		}
-		/// <summary>
-		/// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
-		/// </summary>
-		public string CallerIdNum
-		{
-			get { return callerIdNum; }
-			set { this.callerIdNum = value; }
-		}
-		/// <summary>
-		/// Get/Set the Caller*ID Name of the channel if set or &lt;unknown&gt; if none has been set.
-		/// </summary>
-		public string CallerIdName
-		{
-			get { return callerIdName; }
-			set { this.callerIdName = value; }
-		}
-		/// <summary>
-		/// Get/Set the (new) state of the channel.<br/>
-		/// The following states are used:<br/>
-		/// <ul>
-		/// <li>Down</li>
-		/// <li>OffHook</li>
-		/// <li>Dialing</li>
-		/// <li>Ring</li>
-		/// <li>Ringing</li>
-		/// <li>Up</li>
-		/// <li>Busy</li>
-		/// </ul>
-		/// </summary>
-		public string State
-		{
-			get { return this.state; }
-			set { this.state = value; }
-		}
+        /// <summary>
+        /// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
+        /// </summary>
+        public string CallerId
+        {
+            get { return callerId; }
+            set { this.callerId = value; }
+        }
+        /// <summary>
+        /// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
+        /// </summary>
+        public string CallerIdNum
+        {
+            get { return callerIdNum; }
+            set { this.callerIdNum = value; }
+        }
+        /// <summary>
+        /// Get/Set the Caller*ID Name of the channel if set or &lt;unknown&gt; if none has been set.
+        /// </summary>
+        public string CallerIdName
+        {
+            get { return callerIdName; }
+            set { this.callerIdName = value; }
+        }
+        /// <summary>
+        /// Get/Set the (new) state of the channel.<br/>
+        /// The following states are used:<br/>
+        /// <ul>
+        /// <li>Down</li>
+        /// <li>OffHook</li>
+        /// <li>Dialing</li>
+        /// <li>Ring</li>
+        /// <li>Ringing</li>
+        /// <li>Up</li>
+        /// <li>Busy</li>
+        /// </ul>
+        /// </summary>
+        public string State
+        {
+            get { return this.state; }
+            set { this.state = value; }
+        }
 
-		/// <summary>
-		/// Get/Set channel AccountCode
-		/// </summary>
-		public string AccountCode
-		{
-			get { return this.accountCode; }
-			set { this.accountCode = value; }
-		}
+        /// <summary>
+        /// Get/Set channel AccountCode
+        /// </summary>
+        public string AccountCode
+        {
+            get { return this.accountCode; }
+            set { this.accountCode = value; }
+        }
 
-		public string Connectedlinenum
-		{
-			get { return connectedLineNum; }
-			set { connectedLineNum = value; }
-		}
+        public string Connectedlinenum
+        {
+            get { return connectedLineNum; }
+            set { connectedLineNum = value; }
+        }
 
-		public string ConnectedLineName
-		{
-			get { return connectedLineName; }
-			set { connectedLineName = value; }
-		}
+        public string ConnectedLineName
+        {
+            get { return connectedLineName; }
+            set { connectedLineName = value; }
+        }
 
-		public AbstractChannelEvent(ManagerConnection source)
-			: base(source)
-		{
-		}
-	}
+        public AbstractChannelEvent(ManagerConnection source)
+            : base(source)
+        {
+        }
+    }
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
@@ -1,105 +1,105 @@
 namespace AsterNET.Manager.Event
 {
-    /// <summary>
-    /// Abstract base class providing common properties for HangupEvent, NewChannelEvent and NewStateEvent.
-    /// </summary>
-    public abstract class AbstractChannelEvent : ResponseEvent
-    {
-        private string channelState;
-        private string channelStateDesc;
-        private string callerId;
-        private string callerIdNum;
-        private string callerIdName;
-        private string accountCode;
-        private string state;
-        private string connectedLineNum;
-        private string connectedLineName;
+	/// <summary>
+	/// Abstract base class providing common properties for HangupEvent, NewChannelEvent and NewStateEvent.
+	/// </summary>
+	public abstract class AbstractChannelEvent : ResponseEvent
+	{
+		private string channelState;
+		private string channelStateDesc;
+		private string callerId;
+		private string callerIdNum;
+		private string callerIdName;
+		private string accountCode;
+		private string state;
+		private string connectedLineNum;
+		private string connectedLineName;
 
-        /// <summary>
-        /// Get/Set Channel State
-        /// </summary>
-        public string ChannelState
-        {
-            get { return this.channelState; }
-            set { this.channelState = value; }
-        }
+		/// <summary>
+		/// Get/Set Channel State
+		/// </summary>
+		public string ChannelState
+		{
+			get { return this.channelState; }
+			set { this.channelState = value; }
+		}
 
-        /// <summary>
-        /// Get/Set Channel State Description
-        /// </summary>
-        public string ChannelStateDesc
-        {
-            get { return this.channelStateDesc; }
-            set { this.channelStateDesc = value; }
-        }
+		/// <summary>
+		/// Get/Set Channel State Description
+		/// </summary>
+		public string ChannelStateDesc
+		{
+			get { return this.channelStateDesc; }
+			set { this.channelStateDesc = value; }
+		}
 
-        /// <summary>
-        /// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
-        /// </summary>
-        public string CallerId
-        {
-            get { return callerId; }
-            set { this.callerId = value; }
-        }
-        /// <summary>
-        /// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
-        /// </summary>
-        public string CallerIdNum
-        {
-            get { return callerIdNum; }
-            set { this.callerIdNum = value; }
-        }
-        /// <summary>
-        /// Get/Set the Caller*ID Name of the channel if set or &lt;unknown&gt; if none has been set.
-        /// </summary>
-        public string CallerIdName
-        {
-            get { return callerIdName; }
-            set { this.callerIdName = value; }
-        }
-        /// <summary>
-        /// Get/Set the (new) state of the channel.<br/>
-        /// The following states are used:<br/>
-        /// <ul>
-        /// <li>Down</li>
-        /// <li>OffHook</li>
-        /// <li>Dialing</li>
-        /// <li>Ring</li>
-        /// <li>Ringing</li>
-        /// <li>Up</li>
-        /// <li>Busy</li>
-        /// </ul>
-        /// </summary>
-        public string State
-        {
-            get { return this.state; }
-            set { this.state = value; }
-        }
+		/// <summary>
+		/// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
+		/// </summary>
+		public string CallerId
+		{
+			get { return callerId; }
+			set { this.callerId = value; }
+		}
+		/// <summary>
+		/// Get/Set the Caller*ID of the channel if set or &lt;unknown&gt; if none has been set.
+		/// </summary>
+		public string CallerIdNum
+		{
+			get { return callerIdNum; }
+			set { this.callerIdNum = value; }
+		}
+		/// <summary>
+		/// Get/Set the Caller*ID Name of the channel if set or &lt;unknown&gt; if none has been set.
+		/// </summary>
+		public string CallerIdName
+		{
+			get { return callerIdName; }
+			set { this.callerIdName = value; }
+		}
+		/// <summary>
+		/// Get/Set the (new) state of the channel.<br/>
+		/// The following states are used:<br/>
+		/// <ul>
+		/// <li>Down</li>
+		/// <li>OffHook</li>
+		/// <li>Dialing</li>
+		/// <li>Ring</li>
+		/// <li>Ringing</li>
+		/// <li>Up</li>
+		/// <li>Busy</li>
+		/// </ul>
+		/// </summary>
+		public string State
+		{
+			get { return this.state; }
+			set { this.state = value; }
+		}
 
-        /// <summary>
-        /// Get/Set channel AccountCode
-        /// </summary>
-        public string AccountCode
-        {
-            get { return this.accountCode; }
-            set { this.accountCode = value; }
-        }
+		/// <summary>
+		/// Get/Set channel AccountCode
+		/// </summary>
+		public string AccountCode
+		{
+			get { return this.accountCode; }
+			set { this.accountCode = value; }
+		}
 
-        public string Connectedlinenum
-        {
-            get { return connectedLineNum; }
-            set { connectedLineNum = value; }
-        }
+		public string Connectedlinenum
+		{
+			get { return connectedLineNum; }
+			set { connectedLineNum = value; }
+		}
 
-        public string ConnectedLineName
-        {
-            get { return connectedLineName; }
-            set { connectedLineName = value; }
-        }
+		public string ConnectedLineName
+		{
+			get { return connectedLineName; }
+			set { connectedLineName = value; }
+		}
 
-        public AbstractChannelEvent(ManagerConnection source)
-            : base(source)
-        {
-        }
-    }
+		public AbstractChannelEvent(ManagerConnection source)
+			: base(source)
+		{
+		}
+	}
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/AbstractChannelEvent.cs
@@ -3,7 +3,7 @@ namespace AsterNET.Manager.Event
 	/// <summary>
 	/// Abstract base class providing common properties for HangupEvent, NewChannelEvent and NewStateEvent.
 	/// </summary>
-	public abstract class AbstractChannelEvent : ManagerEvent
+	public abstract class AbstractChannelEvent : ResponseEvent
 	{
 		private string channelState;
 		private string channelStateDesc;
@@ -12,8 +12,8 @@ namespace AsterNET.Manager.Event
 		private string callerIdName;
 		private string accountCode;
 		private string state;
-	    private string connectedLineNum;
-	    private string connectedLineName;
+		private string connectedLineNum;
+		private string connectedLineName;
 
 		/// <summary>
 		/// Get/Set Channel State
@@ -85,19 +85,19 @@ namespace AsterNET.Manager.Event
 			set { this.accountCode = value; }
 		}
 
-	    public string Connectedlinenum
-	    {
-	        get { return connectedLineNum; }
-            set { connectedLineNum = value; }
-	    }
+		public string Connectedlinenum
+		{
+			get { return connectedLineNum; }
+			set { connectedLineNum = value; }
+		}
 
-	    public string ConnectedLineName
-	    {
-	        get { return connectedLineName; }
-	        set { connectedLineName = value; }
-	    }
+		public string ConnectedLineName
+		{
+			get { return connectedLineName; }
+			set { connectedLineName = value; }
+		}
 
-	    public AbstractChannelEvent(ManagerConnection source)
+		public AbstractChannelEvent(ManagerConnection source)
 			: base(source)
 		{
 		}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace AsterNET.Manager.Event
+{
+	/// <summary>
+	/// Raised when a Queue member's status has changed
+	/// </summary>
+	public class CoreShowChannelEvent : AbstractChannelEvent
+	{
+		/// <summary>
+		/// Get/Set Channel
+		/// </summary>
+		public string Channel { get; set; }
+
+		/// <summary>
+		/// Get/Set Channel
+		/// </summary>
+		public string Language { get; set; }
+
+		/// <summary>
+		/// Get/Set Context
+		/// </summary>
+		public string Context { get; set; }
+
+		/// <summary>
+		/// Get/Set Exten
+		/// </summary>
+		public string Exten { get; set; }
+		public string Extennnnnnnnnnsions { get; set; }
+
+		/// <summary>
+		/// Get/Set Priority
+		/// </summary>
+		public int Priority { get; set; }
+
+		/// <summary>
+		/// Get/Set Uniqueid
+		/// </summary>
+		public string Uniqueid { get; set; }
+
+		/// <summary>
+		/// Get/Set Linkedid: Uniqueid of the oldest channel associated with this channel.
+		/// </summary>
+		public string Linkedid { get; set; }
+
+		/// <summary>
+		/// Get/Set Application: Application currently executing on the channel
+		/// </summary>
+		public string Application { get; set; }
+
+		/// <summary>
+		/// Get/Set ApplicationData: Data given to the currently executing application
+		/// </summary>
+		public string ApplicationData { get; set; }
+
+		/// <summary>
+		/// Get/Set Duration: The amount of time the channel has existed
+		/// </summary>
+		public TimeSpan Duration { get; set; }
+
+		/// <summary>
+		/// Get/Set BridgeId: Identifier of the bridge the channel is in, may be empty if not in one
+		/// </summary>
+		public Guid BridgeId { get; set; }
+
+		/// <summary>
+		/// Creates a new CoreShowChannelEvent
+		/// </summary>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
+		public CoreShowChannelEvent(ManagerConnection source)
+			: base(source)
+		{
+		}
+	}
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
@@ -26,7 +26,6 @@ namespace AsterNET.Manager.Event
 		/// Get/Set Exten
 		/// </summary>
 		public string Exten { get; set; }
-		public string Extennnnnnnnnnsions { get; set; }
 
 		/// <summary>
 		/// Get/Set Priority

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelEvent.cs
@@ -2,73 +2,73 @@ using System;
 
 namespace AsterNET.Manager.Event
 {
-	/// <summary>
-	/// Raised when a Queue member's status has changed
-	/// </summary>
-	public class CoreShowChannelEvent : AbstractChannelEvent
-	{
-		/// <summary>
-		/// Get/Set Channel
-		/// </summary>
-		public string Channel { get; set; }
+    /// <summary>
+    /// Raised when a Queue member's status has changed
+    /// </summary>
+    public class CoreShowChannelEvent : AbstractChannelEvent
+    {
+        /// <summary>
+        /// Get/Set Channel
+        /// </summary>
+        public string Channel { get; set; }
 
-		/// <summary>
-		/// Get/Set Channel
-		/// </summary>
-		public string Language { get; set; }
+        /// <summary>
+        /// Get/Set Channel
+        /// </summary>
+        public string Language { get; set; }
 
-		/// <summary>
-		/// Get/Set Context
-		/// </summary>
-		public string Context { get; set; }
+        /// <summary>
+        /// Get/Set Context
+        /// </summary>
+        public string Context { get; set; }
 
-		/// <summary>
-		/// Get/Set Exten
-		/// </summary>
-		public string Exten { get; set; }
+        /// <summary>
+        /// Get/Set Exten
+        /// </summary>
+        public string Exten { get; set; }
 
-		/// <summary>
-		/// Get/Set Priority
-		/// </summary>
-		public int Priority { get; set; }
+        /// <summary>
+        /// Get/Set Priority
+        /// </summary>
+        public int Priority { get; set; }
 
-		/// <summary>
-		/// Get/Set Uniqueid
-		/// </summary>
-		public string Uniqueid { get; set; }
+        /// <summary>
+        /// Get/Set Uniqueid
+        /// </summary>
+        public string Uniqueid { get; set; }
 
-		/// <summary>
-		/// Get/Set Linkedid: Uniqueid of the oldest channel associated with this channel.
-		/// </summary>
-		public string Linkedid { get; set; }
+        /// <summary>
+        /// Get/Set Linkedid: Uniqueid of the oldest channel associated with this channel.
+        /// </summary>
+        public string Linkedid { get; set; }
 
-		/// <summary>
-		/// Get/Set Application: Application currently executing on the channel
-		/// </summary>
-		public string Application { get; set; }
+        /// <summary>
+        /// Get/Set Application: Application currently executing on the channel
+        /// </summary>
+        public string Application { get; set; }
 
-		/// <summary>
-		/// Get/Set ApplicationData: Data given to the currently executing application
-		/// </summary>
-		public string ApplicationData { get; set; }
+        /// <summary>
+        /// Get/Set ApplicationData: Data given to the currently executing application
+        /// </summary>
+        public string ApplicationData { get; set; }
 
-		/// <summary>
-		/// Get/Set Duration: The amount of time the channel has existed
-		/// </summary>
-		public TimeSpan Duration { get; set; }
+        /// <summary>
+        /// Get/Set Duration: The amount of time the channel has existed
+        /// </summary>
+        public TimeSpan Duration { get; set; }
 
-		/// <summary>
-		/// Get/Set BridgeId: Identifier of the bridge the channel is in, may be empty if not in one
-		/// </summary>
-		public Guid BridgeId { get; set; }
+        /// <summary>
+        /// Get/Set BridgeId: Identifier of the bridge the channel is in, may be empty if not in one
+        /// </summary>
+        public Guid BridgeId { get; set; }
 
-		/// <summary>
-		/// Creates a new CoreShowChannelEvent
-		/// </summary>
-		/// <param name="source">ManagerConnection passed through in the event.</param>
-		public CoreShowChannelEvent(ManagerConnection source)
-			: base(source)
-		{
-		}
-	}
+        /// <summary>
+        /// Creates a new CoreShowChannelEvent
+        /// </summary>
+        /// <param name="source">ManagerConnection passed through in the event.</param>
+        public CoreShowChannelEvent(ManagerConnection source)
+            : base(source)
+        {
+        }
+    }
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelsCompleteEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelsCompleteEvent.cs
@@ -1,0 +1,17 @@
+namespace AsterNET.Manager.Event
+{
+	/// <summary>
+	/// Raised when a Queue member's status has changed
+	/// </summary>
+	public class CoreShowChannelsCompleteEvent : ResponseEvent
+	{
+		/// <summary>
+		/// Creates a new CoreShowChannelsCompleteEvent
+		/// </summary>
+		/// <param name="source">ManagerConnection passed through in the event.</param>
+		public CoreShowChannelsCompleteEvent(ManagerConnection source)
+			: base(source)
+		{
+		}
+	}
+}

--- a/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelsCompleteEvent.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/Event/CoreShowChannelsCompleteEvent.cs
@@ -1,17 +1,17 @@
 namespace AsterNET.Manager.Event
 {
-	/// <summary>
-	/// Raised when a Queue member's status has changed
-	/// </summary>
-	public class CoreShowChannelsCompleteEvent : ResponseEvent
-	{
-		/// <summary>
-		/// Creates a new CoreShowChannelsCompleteEvent
-		/// </summary>
-		/// <param name="source">ManagerConnection passed through in the event.</param>
-		public CoreShowChannelsCompleteEvent(ManagerConnection source)
-			: base(source)
-		{
-		}
-	}
+    /// <summary>
+    /// Raised when a Queue member's status has changed
+    /// </summary>
+    public class CoreShowChannelsCompleteEvent : ResponseEvent
+    {
+        /// <summary>
+        /// Creates a new CoreShowChannelsCompleteEvent
+        /// </summary>
+        /// <param name="source">ManagerConnection passed through in the event.</param>
+        public CoreShowChannelsCompleteEvent(ManagerConnection source)
+            : base(source)
+        {
+        }
+    }
 }

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -151,14 +151,21 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<CdrEvent> Cdr;
         public event EventHandler<DBGetResponseEvent> DBGetResponse;
-
-        public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
-        public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
 		/// <summary>
 		/// A Dial is triggered whenever a phone attempts to dial someone.<br/>
 		/// </summary>
 		public event EventHandler<DialEvent> Dial;
-        public event EventHandler<DTMFEvent> DTMF;
+
+		/// <summary>
+		/// An CoreShowChannelEvent is triggered in response to a CoreShowChannelsAction.
+		/// </summary>
+		public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
+		/// <summary>
+		/// An CoreShowChannelsCompleteEvent is triggered when at the end of CoreShowChannelsAction.
+		/// </summary>
+		public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
+
+		public event EventHandler<DTMFEvent> DTMF;
         /// <summary>
         /// An DTMFBeginEvent is triggered when a DTMF digit has started on a channel.
         /// </summary>

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -151,10 +151,13 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<CdrEvent> Cdr;
         public event EventHandler<DBGetResponseEvent> DBGetResponse;
-        /// <summary>
-        /// A Dial is triggered whenever a phone attempts to dial someone.<br/>
-        /// </summary>
-        public event EventHandler<DialEvent> Dial;
+
+        public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
+        public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
+		/// <summary>
+		/// A Dial is triggered whenever a phone attempts to dial someone.<br/>
+		/// </summary>
+		public event EventHandler<DialEvent> Dial;
         public event EventHandler<DTMFEvent> DTMF;
         /// <summary>
         /// An DTMFBeginEvent is triggered when a DTMF digit has started on a channel.
@@ -543,7 +546,10 @@ namespace AsterNET.Manager
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(AlarmEvent), arg => fireEvent(Alarm, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(CdrEvent), arg => fireEvent(Cdr, arg));
 
-            Helper.RegisterEventHandler(registeredEventHandlers, typeof(DBGetResponseEvent), arg => fireEvent(DBGetResponse, arg));
+			Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelEvent), arg => fireEvent(CoreShowChannel, arg));
+			Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelsCompleteEvent), arg => fireEvent(CoreShowChannelsComplete, arg));
+
+			Helper.RegisterEventHandler(registeredEventHandlers, typeof(DBGetResponseEvent), arg => fireEvent(DBGetResponse, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(DialEvent), arg => fireEvent(Dial, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(DNDStateEvent), arg => fireEvent(DNDState, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ExtensionStatusEvent), arg => fireEvent(ExtensionStatus, arg));

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -71,7 +71,7 @@ namespace AsterNET.Manager
         /// <summary> Default Slow Reconnect interval in milliseconds.</summary>
         private int reconnectIntervalMax = 10000;
 
-		public char[] VAR_DELIMITER = { '|' };
+        public char[] VAR_DELIMITER = { '|' };
 
         #endregion
 
@@ -151,11 +151,11 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<CdrEvent> Cdr;
         public event EventHandler<DBGetResponseEvent> DBGetResponse;
-		/// <summary>
-		/// A Dial is triggered whenever a phone attempts to dial someone.<br/>
-		/// </summary>
-		public event EventHandler<DialEvent> Dial;
-		public event EventHandler<DTMFEvent> DTMF;
+        /// <summary>
+        /// A Dial is triggered whenever a phone attempts to dial someone.<br/>
+        /// </summary>
+        public event EventHandler<DialEvent> Dial;
+        public event EventHandler<DTMFEvent> DTMF;
         /// <summary>
         /// An DTMFBeginEvent is triggered when a DTMF digit has started on a channel.
         /// </summary>
@@ -508,20 +508,20 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<QueueSummaryEvent> QueueSummary;
 
-		/// <summary>
-		/// An CoreShowChannelEvent is triggered in response to a CoreShowChannelsAction.
-		/// </summary>
-		public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
-		/// <summary>
-		/// An CoreShowChannelsCompleteEvent is triggered when at the end of CoreShowChannelsAction.
-		/// </summary>
-		public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
+        /// <summary>
+        /// An CoreShowChannelEvent is triggered in response to a CoreShowChannelsAction.
+        /// </summary>
+        public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
+        /// <summary>
+        /// An CoreShowChannelsCompleteEvent is triggered when at the end of CoreShowChannelsAction.
+        /// </summary>
+        public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;k
 
-		#endregion
+        #endregion
 
-		#region Constructor - ManagerConnection()
-		/// <summary> Creates a new instance.</summary>
-		public ManagerConnection()
+        #region Constructor - ManagerConnection()
+        /// <summary> Creates a new instance.</summary>
+        public ManagerConnection()
         {
             callerThread = Thread.CurrentThread;
 
@@ -552,10 +552,10 @@ namespace AsterNET.Manager
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(AlarmEvent), arg => fireEvent(Alarm, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(CdrEvent), arg => fireEvent(Cdr, arg));
 
-			Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelEvent), arg => fireEvent(CoreShowChannel, arg));
-			Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelsCompleteEvent), arg => fireEvent(CoreShowChannelsComplete, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelEvent), arg => fireEvent(CoreShowChannel, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(CoreShowChannelsCompleteEvent), arg => fireEvent(CoreShowChannelsComplete, arg));
 
-			Helper.RegisterEventHandler(registeredEventHandlers, typeof(DBGetResponseEvent), arg => fireEvent(DBGetResponse, arg));
+            Helper.RegisterEventHandler(registeredEventHandlers, typeof(DBGetResponseEvent), arg => fireEvent(DBGetResponse, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(DialEvent), arg => fireEvent(Dial, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(DNDStateEvent), arg => fireEvent(DNDState, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ExtensionStatusEvent), arg => fireEvent(ExtensionStatus, arg));
@@ -648,7 +648,7 @@ namespace AsterNET.Manager
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(ChallengeSentEvent), arg => fireEvent(ChallengeSent, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(SuccessfulAuthEvent), arg => fireEvent(SuccessfulAuth, arg));
             Helper.RegisterEventHandler(registeredEventHandlers, typeof(QueueSummaryEvent), arg => fireEvent(QueueSummary, arg));
-            
+
             #endregion
 
             this.internalEvent += new EventHandler<ManagerEvent>(internalEventHandler);
@@ -913,7 +913,7 @@ namespace AsterNET.Manager
         /// Changing the property doesn't do anything while you are already connected.
         /// </para>
         /// </remarks>
-        public int SocketReceiveBufferSize { get; set;}
+        public int SocketReceiveBufferSize { get; set; }
 
         #endregion
 
@@ -1025,136 +1025,136 @@ namespace AsterNET.Manager
 #if LOGGER
                 logger.Info("Determined Asterisk version: " + asteriskVersion);
 #endif
-				enableEvents = true;
-				ConnectEvent ce = new ConnectEvent(this);
-				ce.ProtocolIdentifier = this.protocolIdentifier;
-				DispatchEvent(ce);
-			}
-			else if (response is ManagerError)
-				throw new ManagerException("Unable login to Asterisk - " + response.Message);
-			else
-				throw new ManagerException("Unknown response during login to Asterisk - " + response.GetType().Name + " with message " + response.Message);
+                enableEvents = true;
+                ConnectEvent ce = new ConnectEvent(this);
+                ce.ProtocolIdentifier = this.protocolIdentifier;
+                DispatchEvent(ce);
+            }
+            else if (response is ManagerError)
+                throw new ManagerException("Unable login to Asterisk - " + response.Message);
+            else
+                throw new ManagerException("Unknown response during login to Asterisk - " + response.GetType().Name + " with message " + response.Message);
 
-		}
-		#endregion
+        }
+        #endregion
 
-		#region determineVersion()
-		protected internal AsteriskVersion determineVersion()
-		{
-			Response.ManagerResponse response;
-			response = SendAction(new Action.CommandAction("core show version"), defaultResponseTimeout * 2);
-			if (response is Response.CommandResponse)
-			{
-				foreach (string line in ((Response.CommandResponse)response).Result)
-				{
-					foreach (Match m in Common.ASTERISK_VERSION.Matches(line))
-					{
-						if (m.Groups.Count >= 2)
-						{
-							version = m.Groups[1].Value;
-							if (version.StartsWith("1.4."))
-							{
-								VAR_DELIMITER = new char[] { '|' };
-								return AsteriskVersion.ASTERISK_1_4;
-							}
-							else if (version.StartsWith("1.6."))
-							{
-								VAR_DELIMITER = new char[] { '|' };
-								return Manager.AsteriskVersion.ASTERISK_1_6;
-							}
-							else if (version.StartsWith("1.8."))
-							{
-								VAR_DELIMITER = new char[] { '|' };
-								return Manager.AsteriskVersion.ASTERISK_1_8;
-							}
-							else if (version.StartsWith("10."))
-							{
-								VAR_DELIMITER = new char[] { '|' };
-								return Manager.AsteriskVersion.ASTERISK_10;
-							}
-							else if (version.StartsWith("11."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_11;
-							}
-							else if (version.StartsWith("12."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_12;
-							}
-							else if (version.StartsWith("13."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_13;
-							}
-							else if (version.StartsWith("14."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_14;
-							}
-							else if (version.StartsWith("15."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_15;
-							}
-							else if (version.StartsWith("16."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_16;
-							}
-							else if (version.StartsWith("17."))
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_17;
-							}
-							else if (version.IndexOf('.') >= 2)
-							{
-								VAR_DELIMITER = new char[] { ',' };
-								return Manager.AsteriskVersion.ASTERISK_Newer;
-							}
-							else
-								throw new ManagerException("Unknown Asterisk version " + version);
-						}
-					}
-				}
-			}
+        #region determineVersion()
+        protected internal AsteriskVersion determineVersion()
+        {
+            Response.ManagerResponse response;
+            response = SendAction(new Action.CommandAction("core show version"), defaultResponseTimeout * 2);
+            if (response is Response.CommandResponse)
+            {
+                foreach (string line in ((Response.CommandResponse)response).Result)
+                {
+                    foreach (Match m in Common.ASTERISK_VERSION.Matches(line))
+                    {
+                        if (m.Groups.Count >= 2)
+                        {
+                            version = m.Groups[1].Value;
+                            if (version.StartsWith("1.4."))
+                            {
+                                VAR_DELIMITER = new char[] { '|' };
+                                return AsteriskVersion.ASTERISK_1_4;
+                            }
+                            else if (version.StartsWith("1.6."))
+                            {
+                                VAR_DELIMITER = new char[] { '|' };
+                                return Manager.AsteriskVersion.ASTERISK_1_6;
+                            }
+                            else if (version.StartsWith("1.8."))
+                            {
+                                VAR_DELIMITER = new char[] { '|' };
+                                return Manager.AsteriskVersion.ASTERISK_1_8;
+                            }
+                            else if (version.StartsWith("10."))
+                            {
+                                VAR_DELIMITER = new char[] { '|' };
+                                return Manager.AsteriskVersion.ASTERISK_10;
+                            }
+                            else if (version.StartsWith("11."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_11;
+                            }
+                            else if (version.StartsWith("12."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_12;
+                            }
+                            else if (version.StartsWith("13."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_13;
+                            }
+                            else if (version.StartsWith("14."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_14;
+                            }
+                            else if (version.StartsWith("15."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_15;
+                            }
+                            else if (version.StartsWith("16."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_16;
+                            }
+                            else if (version.StartsWith("17."))
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_17;
+                            }
+                            else if (version.IndexOf('.') >= 2)
+                            {
+                                VAR_DELIMITER = new char[] { ',' };
+                                return Manager.AsteriskVersion.ASTERISK_Newer;
+                            }
+                            else
+                                throw new ManagerException("Unknown Asterisk version " + version);
+                        }
+                    }
+                }
+            }
 
-			Response.ManagerResponse showVersionFilesResponse = SendAction(new Action.CommandAction("show version files"), defaultResponseTimeout * 2);
-			if (showVersionFilesResponse is Response.CommandResponse)
-			{
-				IList showVersionFilesResult = ((Response.CommandResponse)showVersionFilesResponse).Result;
-				if (showVersionFilesResult != null && showVersionFilesResult.Count > 0)
-				{
-					string line1;
-					line1 = (string)showVersionFilesResult[0];
-					if (line1 != null && line1.StartsWith("File"))
-					{
-						VAR_DELIMITER = new char[] { '|' };
-						return AsteriskVersion.ASTERISK_1_2;
-					}
-				}
-			}
-			return AsteriskVersion.ASTERISK_1_0;
-		}
+            Response.ManagerResponse showVersionFilesResponse = SendAction(new Action.CommandAction("show version files"), defaultResponseTimeout * 2);
+            if (showVersionFilesResponse is Response.CommandResponse)
+            {
+                IList showVersionFilesResult = ((Response.CommandResponse)showVersionFilesResponse).Result;
+                if (showVersionFilesResult != null && showVersionFilesResult.Count > 0)
+                {
+                    string line1;
+                    line1 = (string)showVersionFilesResult[0];
+                    if (line1 != null && line1.StartsWith("File"))
+                    {
+                        VAR_DELIMITER = new char[] { '|' };
+                        return AsteriskVersion.ASTERISK_1_2;
+                    }
+                }
+            }
+            return AsteriskVersion.ASTERISK_1_0;
+        }
 
-		#endregion
+        #endregion
 
-		#region connect()
-		protected internal bool connect()
-		{
-			bool result = false;
-			bool startReader = false;
+        #region connect()
+        protected internal bool connect()
+        {
+            bool result = false;
+            bool startReader = false;
 
-			lock (lockSocket)
-			{
-				if (mrSocket == null)
-				{
+            lock (lockSocket)
+            {
+                if (mrSocket == null)
+                {
 #if LOGGER
                     logger.Info("Connecting to {0}:{1}", hostname, port);
 #endif
                     try
                     {
-                        if (SocketReceiveBufferSize>0)
+                        if (SocketReceiveBufferSize > 0)
                             mrSocket = new SocketConnection(hostname, port, SocketReceiveBufferSize, socketEncoding);
                         else
                             mrSocket = new SocketConnection(hostname, port, socketEncoding);
@@ -1304,8 +1304,8 @@ namespace AsterNET.Manager
                         {
                             logger.Info("Reconnect delay exception : ", ex.Message);
 #else
-						catch
-						{
+                        catch
+                        {
 #endif
                             continue;
                         }
@@ -1323,8 +1323,8 @@ namespace AsterNET.Manager
                         {
                             logger.Info("Connect exception : ", ex.Message);
 #else
-						catch
-						{
+                        catch
+                        {
 #endif
                         }
                         retryCount++;
@@ -1495,7 +1495,7 @@ namespace AsterNET.Manager
         /// <param name="action">action to send</param>
         public Task<ManagerResponse> SendActionAsync(ManagerAction action)
         {
-          return SendActionAsync(action, null);
+            return SendActionAsync(action, null);
         }
         #endregion
 
@@ -1507,19 +1507,19 @@ namespace AsterNET.Manager
         /// <param name="cancellationToken">cancellation Token</param>
         public Task<ManagerResponse> SendActionAsync(ManagerAction action, CancellationTokenSource cancellationToken)
         {
-          var handler = new TaskResponseHandler(action);
-          var source = handler.TaskCompletionSource;
+            var handler = new TaskResponseHandler(action);
+            var source = handler.TaskCompletionSource;
 
-          SendAction(action, handler);
+            SendAction(action, handler);
 
-          if (cancellationToken != null)
-            cancellationToken.Token.Register(() => { source.TrySetCanceled(); });
+            if (cancellationToken != null)
+                cancellationToken.Token.Register(() => { source.TrySetCanceled(); });
 
-          return source.Task.ContinueWith(x =>
-          {
-            RemoveResponseHandler(handler);
-            return x.Result;
-          });
+            return source.Task.ContinueWith(x =>
+            {
+                RemoveResponseHandler(handler);
+                return x.Result;
+            });
         }
         #endregion
         #region SendEventGeneratingAction(action)
@@ -1592,7 +1592,7 @@ namespace AsterNET.Manager
         /// Delete an instance of a class <see cref="IResponseHandler"/> from handlers list.
         /// </summary>
         /// <param name="handler">Class instance <see cref="IResponseHandler"/>.</param>
-		public void RemoveResponseHandler(IResponseHandler handler)
+        public void RemoveResponseHandler(IResponseHandler handler)
         {
             int hash = handler.Hash;
             if (hash != 0)
@@ -1744,7 +1744,7 @@ namespace AsterNET.Manager
                     logger.Error("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
                     continue;
 #else
-					throw new ManagerException("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
+                    throw new ManagerException("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
 #endif
                 }
                 catch (TargetInvocationException ex)
@@ -1753,7 +1753,7 @@ namespace AsterNET.Manager
                     logger.Error("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
                     continue;
 #else
-					throw new ManagerException("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
+                    throw new ManagerException("Unable to retrieve property '" + name + "' of " + action.GetType(), ex);
 #endif
                 }
 
@@ -1886,7 +1886,7 @@ namespace AsterNET.Manager
 #if LOGGER
                         logger.Error("Unexpected exception in responseHandler {0}\n{1}", response, ex);
 #else
-						throw new ManagerException("Unexpected exception in responseHandler " + responseHandler.GetType().FullName, ex);
+                        throw new ManagerException("Unexpected exception in responseHandler " + responseHandler.GetType().FullName, ex);
 #endif
                     }
                 }
@@ -1933,8 +1933,8 @@ namespace AsterNET.Manager
                     {
                         logger.Error("Unable to create login key using MD5 Message Digest", ex);
 #else
-					catch
-					{
+                    catch
+                    {
 #endif
                         key = null;
                     }
@@ -2017,7 +2017,7 @@ namespace AsterNET.Manager
 #if LOGGER
                             logger.Error("Unexpected exception", ex);
 #else
-							throw ex;
+                            throw ex;
 #endif
                         }
                 }
@@ -2056,8 +2056,8 @@ namespace AsterNET.Manager
                     {
                         logger.Info("Send Challenge fail : ", ex.Message);
 #else
-					catch
-					{
+                    catch
+                    {
 #endif
                         disconnect(true);
                     }

--- a/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/ManagerConnection.cs
@@ -155,16 +155,6 @@ namespace AsterNET.Manager
 		/// A Dial is triggered whenever a phone attempts to dial someone.<br/>
 		/// </summary>
 		public event EventHandler<DialEvent> Dial;
-
-		/// <summary>
-		/// An CoreShowChannelEvent is triggered in response to a CoreShowChannelsAction.
-		/// </summary>
-		public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
-		/// <summary>
-		/// An CoreShowChannelsCompleteEvent is triggered when at the end of CoreShowChannelsAction.
-		/// </summary>
-		public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
-
 		public event EventHandler<DTMFEvent> DTMF;
         /// <summary>
         /// An DTMFBeginEvent is triggered when a DTMF digit has started on a channel.
@@ -518,11 +508,20 @@ namespace AsterNET.Manager
         /// </summary>
         public event EventHandler<QueueSummaryEvent> QueueSummary;
 
-        #endregion
+		/// <summary>
+		/// An CoreShowChannelEvent is triggered in response to a CoreShowChannelsAction.
+		/// </summary>
+		public event EventHandler<CoreShowChannelEvent> CoreShowChannel;
+		/// <summary>
+		/// An CoreShowChannelsCompleteEvent is triggered when at the end of CoreShowChannelsAction.
+		/// </summary>
+		public event EventHandler<CoreShowChannelsCompleteEvent> CoreShowChannelsComplete;
 
-        #region Constructor - ManagerConnection()
-        /// <summary> Creates a new instance.</summary>
-        public ManagerConnection()
+		#endregion
+
+		#region Constructor - ManagerConnection()
+		/// <summary> Creates a new instance.</summary>
+		public ManagerConnection()
         {
             callerThread = Thread.CurrentThread;
 


### PR DESCRIPTION
Better support CoreShowChannelsAction:

MAIN:
AbstractChannelEvent now inherits ResponseEvent;
CoreShowChannelsAction now inherits ManagerActionEvent; 
Added events CoreShowChannelEvent and ;CoreShowChannelsCompleteEvent;

BTW:
Added support for TimeSpan and Guid properies in Parsing and ToString methods;
Added AssemblyInfo attributes autogeneration ignore - this gives build an error in VS 2022

EXAMPLE:
Now you can use CoreShowChannelsAction and receives its responses:
```
var action = new CoreShowChannelsAction();
var responses = manager.SendEventGeneratingAction(action);
```

